### PR TITLE
Migrate to use 'shared-everything-threads' naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 [![CI for specs](https://github.com/WebAssembly/spec/actions/workflows/ci-spec.yml/badge.svg)](https://github.com/WebAssembly/spec/actions/workflows/ci-spec.yml)
 [![CI for interpreter & tests](https://github.com/WebAssembly/spec/actions/workflows/ci-interpreter.yml/badge.svg)](https://github.com/WebAssembly/spec/actions/workflows/ci-interpreter.yml)
 
-# [DRAFT] Thread Spawning Proposal
+# [DRAFT] Shared-Everything Threads Proposal
 
-This repository proposes a new WebAssembly instruction for spawning threads. It is a fork of the
-[spec] repository for easier merging later. It is based on the [threads] proposal as a baseline,
+This repository proposes additions to the WebAssembly specification for spawning and managing
+threads &mdash; everything not covered by the already-approved [threads] proposal. It is a fork of
+the [spec] repository for easier merging later. It is based on the [threads] proposal as a baseline,
 though those spec changes are not yet included here. Read the [overview] for details.
 
 [spec]: https://github.com/WebAssembly/spec
 [threads]: https://github.com/WebAssembly/threads
-[overview]: proposals/thread-spawn/Overview.md
+[overview]: proposals/shared-everything-threads/Overview.md
 
 Original `README` from upstream repository follows...
 

--- a/proposals/shared-everything-threads/Overview.md
+++ b/proposals/shared-everything-threads/Overview.md
@@ -1,4 +1,7 @@
-# [DRAFT] Thread Spawn Proposal
+# [DRAFT] Shared-Everything Threads Proposal
+
+> __WARNING__: this page is under active development as we merge in various ideas discussed while
+> reaching phase 1 approval &mdash; expect significant changes soon!
 
 This page describes a proposal to allow WebAssembly modules to spawn threads from within the
 WebAssembly language. This is done with several additions to the specification (each addition is


### PR DESCRIPTION
@tlively, @conrad-watt: this changes the top-level naming and paves the way for future changes. I figured a warning on the overview page is enough for now while we hack on the document.