### PR TITLE
Upstream initial test suite from `wasm-tools`

### DIFF
--- a/test/core/shared-everything-threads/shared-everything-threads/arrays.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/arrays.wast
@@ -1,0 +1,894 @@
+;; Shared array declaration syntax.
+(module
+  (type (shared (array i8)))
+  (type (sub final (shared (array i8))))
+  (rec
+    (type (sub final (shared (array i8))))
+  )
+
+  (global (ref 0) (array.new_default 1 (i32.const 1)))
+  (global (ref 1) (array.new_default 2 (i32.const 1)))
+  (global (ref 2) (array.new_default 0 (i32.const 1)))
+)
+
+;; Shared arrays are distinct from non-shared arrays.
+(assert_invalid
+  (module
+    (type (shared (array i8)))
+    (type (array i8))
+
+    (global (ref 0) (array.new_default 1 (i32.const 1)))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type (shared (array i8)))
+    (type (array i8))
+
+    (global (ref 1) (array.new 0))
+  )
+  "type mismatch"
+)
+
+;; Shared arrays may not be subtypes of non-shared arrays.
+(assert_invalid
+  (module
+    (type (sub (array i8)))
+    (type (sub 0 (shared (array i8))))
+  )
+  "sub type must match super type"
+)
+
+;; Non-shared arrays may not be subtypes of shared arrays.
+(assert_invalid
+  (module
+    (type (sub (shared (array i8))))
+    (type (sub 0 (array i8)))
+  )
+  "sub type must match super type"
+)
+
+;; Shared arrays may not contain non-shared references.
+(assert_invalid
+  (module
+    (type (shared (array anyref)))
+  )
+  "must contain shared type"
+)
+
+;; But they may contain shared references.
+(module
+  (type (shared (array (ref null (shared any)))))
+)
+
+;; Non-shared arrays may contain shared references.
+(module
+  (type (array (ref null (shared any))))
+)
+
+;; Array instructions work on shared arrays.
+(module
+  (type $i8 (shared (array (mut i8))))
+  (type $i32 (shared (array (mut i32))))
+  (type $unshared (array (mut i8)))
+
+  (data)
+  (elem arrayref)
+
+  (func (array.new $i8 (i32.const 0) (i32.const 0)) (drop))
+
+  (func (array.new_default $i8 (i32.const 0)) (drop))
+
+  (func (array.new_fixed $i8 0) (drop))
+
+  (func (param (ref null $i8))
+    (array.get_s $i8 (local.get 0) (i32.const 0)) (drop))
+
+  (func (param (ref null $i8))
+    (array.get_u $i8 (local.get 0) (i32.const 0)) (drop))
+
+  (func (param (ref null $i32))
+    (array.get $i32 (local.get 0) (i32.const 0)) (drop))
+
+  (func (param (ref null $i8))
+    (array.set $i8 (local.get 0) (i32.const 0) (i32.const 0)))
+
+  (func (param (ref null $i8) (ref null $i8))
+    (array.copy $i8 $i8 (local.get 0) (i32.const 0) (local.get 1) (i32.const 0) (i32.const 0)))
+
+  (func (param (ref null $i8) (ref null $unshared))
+    (array.copy $i8 $unshared (local.get 0) (i32.const 0) (local.get 1) (i32.const 0) (i32.const 0)))
+
+  (func (param (ref null $unshared) (ref null $i8))
+    (array.copy $unshared $i8 (local.get 0) (i32.const 0) (local.get 1) (i32.const 0) (i32.const 0)))
+
+  (func (param (ref null $i8))
+    (array.fill $i8 (local.get 0) (i32.const 0) (i32.const 0) (i32.const 0)))
+
+  (func (param (ref null $i8))
+    (array.init_data $i8 0 (local.get 0) (i32.const 0) (i32.const 0) (i32.const 0)))
+
+  (func (param (ref null $i8))
+    (array.init_data $i8 0 (local.get 0) (i32.const 0) (i32.const 0) (i32.const 0)))
+)
+
+;; Bottom types can be used as shared arrays.
+(module
+  (type $i8 (shared (array (mut i8))))
+  (type $i32 (shared (array (mut i32))))
+  (type $funcs (shared (array (mut (ref null (shared func))))))
+
+  (data)
+  ;; See https://github.com/bytecodealliance/wasm-tools/issues/1717.
+  (elem (ref null (shared func)))
+
+  (func (array.get_s $i8 (ref.null (shared none)) (i32.const 0)) (drop))
+  (func (array.get_u $i8 (ref.null (shared none)) (i32.const 0)) (drop))
+  (func (array.get $i32 (ref.null (shared none)) (i32.const 0)) (drop))
+  (func (array.set $i8 (ref.null (shared none)) (i32.const 0) (i32.const 0)))
+  (func (param (ref null $i8))
+    (array.copy $i8 $i8 (ref.null (shared none)) (i32.const 0) (local.get 0) (i32.const 0) (i32.const 0)))
+  (func (param (ref null $i8))
+    (array.copy $i8 $i8 (local.get 0) (i32.const 0) (ref.null (shared none)) (i32.const 0) (i32.const 0)))
+  (func (array.copy $i8 $i8 (ref.null (shared none)) (i32.const 0) (ref.null (shared none)) (i32.const 0) (i32.const 0)))
+  (func (array.fill $i8 (ref.null (shared none)) (i32.const 0) (i32.const 0) (i32.const 0)))
+  (func (array.init_data $i8 0 (ref.null (shared none)) (i32.const 0) (i32.const 0) (i32.const 0)))
+  (func (array.init_elem $funcs 0 (ref.null (shared none)) (i32.const 0) (i32.const 0) (i32.const 0)))
+)
+
+;; Check that field-modifying instructions only work on mutable fields.
+(assert_invalid
+  (module
+    (type $a (shared (array (ref (shared any)))))
+    (func (param $a (ref $a)) (param $ar (ref (shared any))) (result (ref (shared any)))
+      (array.atomic.set seq_cst $a (local.get $a) (i32.const 0) (local.get $ar))
+    )
+  )
+  "array is immutable"
+)
+(assert_invalid
+  (module
+    (type $a (shared (array i32)))
+    (func (param $a (ref $a)) (result i32)
+      (array.atomic.rmw.add seq_cst $a (local.get $a) (i32.const 0) (i32.const 1))
+    )
+  )
+  "array is immutable"
+)
+(assert_invalid
+  (module
+    (type $a (shared (array i64)))
+    (func (param $a (ref $a)) (result i64)
+      (array.atomic.rmw.sub seq_cst $a (local.get $a) (i32.const 0) (i64.const 1))
+    )
+  )
+  "array is immutable"
+)
+(assert_invalid
+  (module
+    (type $a (shared (array i32)))
+    (func (param $a (ref $a)) (result i32)
+      (array.atomic.rmw.and acq_rel $a (local.get $a) (i32.const 0) (i32.const 1))
+    )
+  )
+  "array is immutable"
+)
+(assert_invalid
+  (module
+    (type $a (shared (array i64)))
+    (func (param $a (ref $a)) (result i64)
+      (array.atomic.rmw.or acq_rel $a (local.get $a) (i32.const 0) (i64.const 1))
+    )
+  )
+  "array is immutable"
+)
+(assert_invalid
+  (module
+    (type $a (shared (array i32)))
+    (func (param $a (ref $a)) (result i32)
+      (array.atomic.rmw.xor seq_cst $a (local.get $a) (i32.const 0) (i32.const 1))
+    )
+  )
+  "array is immutable"
+)
+(assert_invalid
+  (module
+    (type $a (shared (array (ref (shared any)))))
+    (func (param $a (ref $a)) (param $ar (ref (shared any))) (result (ref (shared any)))
+      (array.atomic.rmw.xchg seq_cst $a (local.get $a) (i32.const 0) (local.get $ar))
+    )
+  )
+  "array is immutable"
+)
+(assert_invalid
+  (module
+    (type $a (shared (array (ref (shared eq)))))
+    (func (param $a (ref $a)) (param $e1 (ref (shared eq))) (param $e2 (ref (shared eq))) (result)
+      (array.atomic.rmw.cmpxchg acq_rel $a (local.get $a) (i32.const 0) (local.get $e1) (local.get $e2))
+    )
+  )
+  "array is immutable"
+)
+
+;; Exhaustively check `array.atomic.rmw.*` instructions.
+(module (; get, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-get-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get seq_cst $a)
+)
+
+(module (; get, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-get-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (result i64)
+    local.get $x
+    local.get $y
+    array.atomic.get seq_cst $a)
+)
+
+(module (; get, anyref, seq_cst ;)
+  (type $a (shared (array (mut (ref null (shared any))))))
+  (func (export "array-atomic-get-anyref-seq_cst") (param $x (ref null $a)) (param $y i32) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    array.atomic.get seq_cst $a)
+)
+
+(module (; get, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-get-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get acq_rel $a)
+)
+
+(module (; get, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-get-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (result i64)
+    local.get $x
+    local.get $y
+    array.atomic.get acq_rel $a)
+)
+
+(module (; get, anyref, acq_rel ;)
+  (type $a (shared (array (mut (ref null (shared any))))))
+  (func (export "array-atomic-get-anyref-acq_rel") (param $x (ref null $a)) (param $y i32) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    array.atomic.get acq_rel $a)
+)
+
+(module (; get_s, i8, seq_cst ;)
+  (type $a (shared (array (mut i8))))
+  (func (export "array-atomic-get_s-i8-seq_cst") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_s seq_cst $a)
+)
+
+(module (; get_s, i16, seq_cst ;)
+  (type $a (shared (array (mut i16))))
+  (func (export "array-atomic-get_s-i16-seq_cst") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_s seq_cst $a)
+)
+
+(module (; get_s, i8, acq_rel ;)
+  (type $a (shared (array (mut i8))))
+  (func (export "array-atomic-get_s-i8-acq_rel") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_s acq_rel $a)
+)
+
+(module (; get_s, i16, acq_rel ;)
+  (type $a (shared (array (mut i16))))
+  (func (export "array-atomic-get_s-i16-acq_rel") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_s acq_rel $a)
+)
+
+(module (; get_u, i8, seq_cst ;)
+  (type $a (shared (array (mut i8))))
+  (func (export "array-atomic-get_u-i8-seq_cst") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_u seq_cst $a)
+)
+
+(module (; get_u, i16, seq_cst ;)
+  (type $a (shared (array (mut i16))))
+  (func (export "array-atomic-get_u-i16-seq_cst") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_u seq_cst $a)
+)
+
+(module (; get_u, i8, acq_rel ;)
+  (type $a (shared (array (mut i8))))
+  (func (export "array-atomic-get_u-i8-acq_rel") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_u acq_rel $a)
+)
+
+(module (; get_u, i16, acq_rel ;)
+  (type $a (shared (array (mut i16))))
+  (func (export "array-atomic-get_u-i16-acq_rel") (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_u acq_rel $a)
+)
+
+(module (; set, i8, seq_cst ;)
+  (type $a (shared (array (mut i8))))
+  (func (export "array-atomic-set-i8-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set seq_cst $a)
+)
+
+(module (; set, i16, seq_cst ;)
+  (type $a (shared (array (mut i16))))
+  (func (export "array-atomic-set-i16-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set seq_cst $a)
+)
+
+(module (; set, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-set-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set seq_cst $a)
+)
+
+(module (; set, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-set-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set seq_cst $a)
+)
+
+(module (; set, anyref, seq_cst ;)
+  (type $a (shared (array (mut (ref null (shared any))))))
+  (func (export "array-atomic-set-anyref-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set seq_cst $a)
+)
+
+(module (; set, i8, acq_rel ;)
+  (type $a (shared (array (mut i8))))
+  (func (export "array-atomic-set-i8-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set acq_rel $a)
+)
+
+(module (; set, i16, acq_rel ;)
+  (type $a (shared (array (mut i16))))
+  (func (export "array-atomic-set-i16-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set acq_rel $a)
+)
+
+(module (; set, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-set-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set acq_rel $a)
+)
+
+(module (; set, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-set-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set acq_rel $a)
+)
+
+(module (; set, anyref, acq_rel ;)
+  (type $a (shared (array (mut (ref null (shared any))))))
+  (func (export "array-atomic-set-anyref-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.set acq_rel $a)
+)
+
+(module (; rmw.add, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.add-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.add seq_cst $a)
+)
+
+(module (; rmw.add, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.add-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.add seq_cst $a)
+)
+
+(module (; rmw.add, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.add-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.add acq_rel $a)
+)
+
+(module (; rmw.add, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.add-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.add acq_rel $a)
+)
+
+(module (; rmw.sub, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.sub-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.sub seq_cst $a)
+)
+
+(module (; rmw.sub, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.sub-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.sub seq_cst $a)
+)
+
+(module (; rmw.sub, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.sub-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.sub acq_rel $a)
+)
+
+(module (; rmw.sub, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.sub-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.sub acq_rel $a)
+)
+
+(module (; rmw.and, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.and-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.and seq_cst $a)
+)
+
+(module (; rmw.and, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.and-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.and seq_cst $a)
+)
+
+(module (; rmw.and, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.and-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.and acq_rel $a)
+)
+
+(module (; rmw.and, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.and-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.and acq_rel $a)
+)
+
+(module (; rmw.or, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.or-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.or seq_cst $a)
+)
+
+(module (; rmw.or, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.or-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.or seq_cst $a)
+)
+
+(module (; rmw.or, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.or-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.or acq_rel $a)
+)
+
+(module (; rmw.or, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.or-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.or acq_rel $a)
+)
+
+(module (; rmw.xor, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.xor-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xor seq_cst $a)
+)
+
+(module (; rmw.xor, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.xor-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xor seq_cst $a)
+)
+
+(module (; rmw.xor, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.xor-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xor acq_rel $a)
+)
+
+(module (; rmw.xor, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.xor-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xor acq_rel $a)
+)
+
+(module (; rmw.xchg, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.xchg-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xchg seq_cst $a)
+)
+
+(module (; rmw.xchg, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.xchg-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xchg seq_cst $a)
+)
+
+(module (; rmw.xchg, anyref, seq_cst ;)
+  (type $a (shared (array (mut (ref null (shared any))))))
+  (func (export "array-atomic-rmw.xchg-anyref-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xchg seq_cst $a)
+)
+
+(module (; rmw.xchg, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.xchg-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xchg acq_rel $a)
+)
+
+(module (; rmw.xchg, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.xchg-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xchg acq_rel $a)
+)
+
+(module (; rmw.xchg, anyref, acq_rel ;)
+  (type $a (shared (array (mut (ref null (shared any))))))
+  (func (export "array-atomic-rmw.xchg-anyref-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xchg acq_rel $a)
+)
+
+(module (; rmw.cmpxchg, i32, seq_cst ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.cmpxchg-i32-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i32) (param $A i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    local.get $A
+    array.atomic.rmw.cmpxchg seq_cst $a)
+)
+
+(module (; rmw.cmpxchg, i64, seq_cst ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.cmpxchg-i64-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z i64) (param $A i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    local.get $A
+    array.atomic.rmw.cmpxchg seq_cst $a)
+)
+
+(module (; rmw.cmpxchg, eqref, seq_cst ;)
+  (type $a (shared (array (mut (ref null (shared eq))))))
+  (func (export "array-atomic-rmw.cmpxchg-eqref-seq_cst") (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared eq))) (param $A (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    local.get $z
+    local.get $A
+    array.atomic.rmw.cmpxchg seq_cst $a)
+)
+
+(module (; rmw.cmpxchg, i32, acq_rel ;)
+  (type $a (shared (array (mut i32))))
+  (func (export "array-atomic-rmw.cmpxchg-i32-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i32) (param $A i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    local.get $A
+    array.atomic.rmw.cmpxchg acq_rel $a)
+)
+
+(module (; rmw.cmpxchg, i64, acq_rel ;)
+  (type $a (shared (array (mut i64))))
+  (func (export "array-atomic-rmw.cmpxchg-i64-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z i64) (param $A i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    local.get $A
+    array.atomic.rmw.cmpxchg acq_rel $a)
+)
+
+(module (; rmw.cmpxchg, eqref, acq_rel ;)
+  (type $a (shared (array (mut (ref null (shared eq))))))
+  (func (export "array-atomic-rmw.cmpxchg-eqref-acq_rel") (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared eq))) (param $A (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    local.get $z
+    local.get $A
+    array.atomic.rmw.cmpxchg acq_rel $a)
+)
+
+(assert_invalid (; get, i8 ;)
+  (module
+    (type $a (shared (array (mut i8))))
+  (func (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get seq_cst $a)
+  )
+  "packed storage type"
+)
+(assert_invalid (; get_s, i32 ;)
+  (module
+    (type $a (shared (array (mut i32))))
+  (func (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_s seq_cst $a)
+  )
+  "non-packed storage type"
+)
+(assert_invalid (; get_s, anyref ;)
+  (module
+    (type $a (shared (array (mut (ref null (shared any))))))
+  (func (param $x (ref null $a)) (param $y i32) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    array.atomic.get_s seq_cst $a)
+  )
+  "non-packed storage type"
+)
+(assert_invalid (; get_u, i32 ;)
+  (module
+    (type $a (shared (array (mut i32))))
+  (func (param $x (ref null $a)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    array.atomic.get_u seq_cst $a)
+  )
+  "non-packed storage type"
+)
+(assert_invalid (; get_u, anyref ;)
+  (module
+    (type $a (shared (array (mut (ref null (shared any))))))
+  (func (param $x (ref null $a)) (param $y i32) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    array.atomic.get_u seq_cst $a)
+  )
+  "non-packed storage type"
+)
+(assert_invalid (; rmw.add, anyref ;)
+  (module
+    (type $a (shared (array (mut (ref null (shared any))))))
+  (func (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.add seq_cst $a)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.sub, anyref ;)
+  (module
+    (type $a (shared (array (mut (ref null (shared any))))))
+  (func (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.sub seq_cst $a)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.and, anyref ;)
+  (module
+    (type $a (shared (array (mut (ref null (shared any))))))
+  (func (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.and seq_cst $a)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.or, anyref ;)
+  (module
+    (type $a (shared (array (mut (ref null (shared any))))))
+  (func (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.or seq_cst $a)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.xor, anyref ;)
+  (module
+    (type $a (shared (array (mut (ref null (shared any))))))
+  (func (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xor seq_cst $a)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.xchg, i8 ;)
+  (module
+    (type $a (shared (array (mut i8))))
+  (func (param $x (ref null $a)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    array.atomic.rmw.xchg seq_cst $a)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.cmpxchg, i8 ;)
+  (module
+    (type $a (shared (array (mut i8))))
+  (func (param $x (ref null $a)) (param $y i32) (param $z i32) (param $A i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    local.get $A
+    array.atomic.rmw.cmpxchg seq_cst $a)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.cmpxchg, anyref ;)
+  (module
+    (type $a (shared (array (mut (ref null (shared any))))))
+  (func (param $x (ref null $a)) (param $y i32) (param $z (ref null (shared any))) (param $A (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    local.get $A
+    array.atomic.rmw.cmpxchg seq_cst $a)
+  )
+  "invalid type"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (array f32)))
+    (func
+      unreachable
+      array.atomic.get seq_cst $s
+      drop
+    ))
+  "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (array (ref (shared func)))))
+    (func
+      unreachable
+      array.atomic.get seq_cst $s
+      drop
+    ))
+  "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (array i8)))
+    (func
+      unreachable
+      array.atomic.get seq_cst $s
+      drop
+    ))
+  "cannot use array.get with packed storage types"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (array (mut (ref (shared extern))))))
+    (func
+      unreachable
+      array.atomic.set seq_cst $s
+    ))
+  "invalid type: `array.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`"
+)

--- a/test/core/shared-everything-threads/shared-everything-threads/builtins.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/builtins.wast
@@ -1,0 +1,42 @@
+;; Styled after ../component-model/resources.wast
+
+(component
+  (core type $start (shared (func (param $context i32))))
+  (core func $spawn (canon thread.spawn $start))
+  (core func $concurrency (canon thread.hw_concurrency))
+)
+
+(component
+  (core type $start (shared (func (param $context i32))))
+  (core func $spawn (canon thread.spawn $start))
+  (core func $concurrency (canon thread.hw_concurrency))
+
+  (core module $m
+    (type $st (shared (func (param $context i32))))
+    (import "" "spawn" (func (param (ref null $st)) (param i32) (result i32)))
+    (import "" "concurrency" (func (result i32)))
+  )
+
+  (core instance (instantiate $m
+    (with "" (instance
+      (export "spawn" (func $spawn))
+      (export "concurrency" (func $concurrency))
+    ))
+  ))
+)
+
+(assert_invalid
+  (component
+    (core type $start (func))
+    (core func $spawn (canon thread.spawn $start))
+  )
+  "spawn type must be shared"
+)
+
+(assert_invalid
+  (component
+    (core type $start (shared (func)))
+    (core func $spawn (canon thread.spawn $start))
+  )
+  "spawn function must take a single `i32` argument (currently)"
+)

--- a/test/core/shared-everything-threads/shared-everything-threads/funcs.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/funcs.wast
@@ -1,0 +1,64 @@
+;; Check that shared functions are valid WAT.
+(module
+  (type $f (shared (func)))
+  (func (import "spectest" "shared-func") (type $f))
+  (func (type $f))
+)
+
+;; Check that unshared functions cannot be called from shared functions.
+(assert_invalid
+  (module
+    (type $shared (shared (func)))
+    (type $unshared (func))
+    (func (type $shared)
+      call $unshared)
+    (func $unshared (type $unshared))
+  )
+  "shared functions cannot access unshared functions")
+
+;; Check that unshared globals cannot be accessed from shared functions.
+(assert_invalid
+  (module
+    (global $unshared_global i32 (i32.const 0))
+    (type $shared_func (shared (func)))
+    (func (type $shared_func)
+      global.get $unshared_global
+      drop)
+    )
+  "shared functions cannot access unshared globals")
+
+;; Check that unshared tables cannot be accessed from shared functions.
+(assert_invalid
+  (module
+    (table $unshared_table 1 anyref)
+    (type $shared_func (shared (func)))
+    (func (type $shared_func)
+      i32.const 0
+      table.get $unshared_table
+      drop)
+    )
+  "shared functions cannot access unshared tables")
+
+;; Check that unshared arrays cannot be accessed from shared functions.
+(assert_invalid
+  (module
+    (type $unshared_array (array anyref))
+    (type $shared_func (shared (func)))
+    (func (type $shared_func)
+      (array.new $unshared_array (ref.null any) (i32.const 0))
+      (array.get $unshared_array (i32.const 0))
+      drop)
+    )
+  "shared functions cannot access unshared arrays")
+
+;; Check that unshared structs cannot be accessed from shared functions.
+(assert_invalid
+  (module
+    (type $unshared_struct (struct (field i32)))
+    (type $shared_func (shared (func)))
+    (func (type $shared_func)
+      (struct.new $unshared_struct (i32.const 0))
+      (struct.get $unshared_struct 0)
+      drop)
+    )
+  "shared functions cannot access unshared structs")

--- a/test/core/shared-everything-threads/shared-everything-threads/gc-unreachable.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/gc-unreachable.wast
@@ -1,0 +1,152 @@
+(module
+  (func
+    unreachable
+    ref.null (shared eq)
+    ref.eq
+    drop
+
+    ref.null eq
+    ref.eq
+    drop
+  )
+  (func
+    unreachable
+    any.convert_extern
+    ref.cast (ref i31)
+    drop
+  )
+  (func
+    unreachable
+    any.convert_extern
+    ref.cast (ref (shared i31))
+    drop
+  )
+  (func
+    unreachable
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null (shared eq)))
+    unreachable
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null eq))
+    unreachable
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null eq))
+    unreachable
+    ref.cast (ref eq)
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null (shared eq)))
+    unreachable
+    ref.cast (ref (shared eq))
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null (shared eq)))
+    unreachable
+    any.convert_extern
+    extern.convert_any
+    any.convert_extern
+    ref.cast (ref (shared eq))
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null eq))
+    unreachable
+    any.convert_extern
+    extern.convert_any
+    any.convert_extern
+    ref.cast (ref eq)
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    unreachable
+    any.convert_extern
+    ref.cast (ref (shared array))
+    array.len
+    drop
+  )
+)
+
+(assert_invalid
+  (module
+    (func
+      unreachable
+      any.convert_extern
+      ref.null eq
+      ref.eq
+      drop
+    )
+  )
+  "expected subtype of eq, found any")
+
+(assert_invalid
+  (module
+    (func
+      unreachable
+      extern.convert_any
+      ref.cast (ref (shared i31))
+      drop
+    )
+  )
+  "expected (shared anyref), found (ref (shared extern))")
+
+(assert_invalid
+  (module
+    (func
+      unreachable
+      any.convert_extern
+      ref.cast (ref extern)
+      drop
+    )
+  )
+  "expected externref, found (ref any)")
+(assert_invalid
+  (module
+    (func
+      unreachable
+      any.convert_extern
+      array.len
+      drop
+    )
+  )
+  "expected subtype of array, found any")
+(assert_invalid
+  (module
+    (func
+      unreachable
+      ref.as_non_null
+      i32.eq
+      drop
+    )
+  )
+  "expected i32, found heap type")
+(assert_invalid
+  (module
+    (func
+      block $l
+        unreachable
+        br_on_cast $l (ref any) (ref any)
+      end
+    )
+  )
+  "br_on_cast to label with empty types")

--- a/test/core/shared-everything-threads/shared-everything-threads/globals.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/globals.wast
@@ -1,0 +1,429 @@
+;; Check the `shared` attribute on globals.
+
+(module
+  ;; Imported.
+  (global (import "spectest" "global_i32") (shared i32))
+  (global (import "spectest" "global_i32_mut") (shared mut i32))
+  (global (import "spectest" "global_i64") (shared i64))
+  (global (import "spectest" "global_i64_mut") (shared mut i64))
+  (global (import "spectest" "global_f32") (shared i32))
+  (global (import "spectest" "global_f32_mut") (shared mut f32))
+  (global (import "spectest" "global_f64") (shared f64))
+  (global (import "spectest" "global_f64_mut") (shared mut f64))
+  (global (import "spectest" "global_v128") (shared v128))
+  (global (import "spectest" "global_v128_mut") (shared mut v128))
+
+  ;; Initialized.
+  (global (shared i32) (i32.const 0))
+  (global (shared mut i32) (i32.const 0))
+  (global (shared i64) (i64.const 0))
+  (global (shared mut i64) (i64.const 0))
+  (global (shared f32) (f32.const 0))
+  (global (shared mut f32) (f32.const 0))
+  (global (shared f64) (f64.const 0))
+  (global (shared mut f64) (f64.const 0))
+  (global (shared v128) (v128.const i64x2 0 0))
+  (global (shared mut v128) (v128.const i64x2 0 0))
+)
+
+(assert_malformed
+  (module quote "(global (mut shared i64) (i64.const -1))")
+  "unexpected token")
+
+(assert_invalid
+  (module (global $a (import "spectest" "global_ref") (shared funcref)))
+  "shared value type")
+
+;; Check global.atomic.get, global.atomic.set.
+(module
+  (global $a (import "spectest" "global_i32") (shared i32))
+  (global $b (import "spectest" "global_i64") (shared mut i64))
+  (global $d (shared i32) (i32.const 0))
+  (global $e (shared mut i64) (i64.const 1))
+
+  (func (export "get-a-seqcst") (result i32) (global.atomic.get seq_cst $a))
+  (func (export "set-b-seqcst") (global.atomic.set seq_cst $b (i64.const 1)))
+  (func (export "get-d-acqrel") (result i32) (global.atomic.get acq_rel $d))
+  (func (export "set-e-acqrel") (global.atomic.set acq_rel $e (i64.const 2)))
+)
+
+(assert_invalid
+  (module
+    (global $a (shared i32) (i32.const 0))
+    (func (export "set-shared") (global.atomic.set seq_cst $a (i32.const 1)))
+  )
+  "global is immutable")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f32) (f32.const 0))
+    (func (result f32) (global.atomic.get seq_cst $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f32) (f32.const 0))
+    (func (global.atomic.set seq_cst $a (f32.const 0)))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f32) (f32.const 0))
+    (func (result f32) (global.atomic.get acq_rel $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f32) (f32.const 0))
+    (func (global.atomic.set acq_rel $a (f32.const 0)))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared f32) (f32.const 0))
+    (func (result f32) (global.atomic.get seq_cst $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared f32) (f32.const 0))
+    (func (result f32) (global.atomic.get acq_rel $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f64) (f64.const 0))
+    (func (result f64) (global.atomic.get seq_cst $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f64) (f64.const 0))
+    (func (global.atomic.set seq_cst $a (f64.const 0)))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f64) (f64.const 0))
+    (func (result f64) (global.atomic.get acq_rel $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f64) (f64.const 0))
+    (func (global.atomic.set acq_rel $a (f64.const 0)))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared f64) (f64.const 0))
+    (func (result f64) (global.atomic.get seq_cst $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared f64) (f64.const 0))
+    (func (result f64) (global.atomic.get acq_rel $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut v128) (v128.const i64x2 0 0))
+    (func (result v128) (global.atomic.get seq_cst $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut v128) (v128.const i64x2 0 0))
+    (func (global.atomic.set seq_cst $a (v128.const i64x2 0 0)))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut v128) (v128.const i64x2 0 0))
+    (func (result v128) (global.atomic.get acq_rel $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared mut v128) (v128.const i64x2 0 0))
+    (func (global.atomic.set acq_rel $a (v128.const i64x2 0 0)))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared v128) (v128.const i64x2 0 0))
+    (func (result v128) (global.atomic.get seq_cst $a))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (shared v128) (v128.const i64x2 0 0))
+    (func (result v128) (global.atomic.get acq_rel $a))
+  )
+  "invalid type")
+
+;; Check global.atomic.rmw.*.
+(module (;i32;)
+  (global $a (import "spectest" "global_i32") (shared mut i32))
+  (global $b (shared mut i32) (i32.const 0))
+  (func (export "rmw-add-i32-seq_cst-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.add seq_cst $a)
+  (func (export "rmw-add-i32-seq_cst-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.add seq_cst $b)
+  (func (export "rmw-add-i32-acq_rel-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.add acq_rel $a)
+  (func (export "rmw-add-i32-acq_rel-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.add acq_rel $b)
+  (func (export "rmw-sub-i32-seq_cst-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.sub seq_cst $a)
+  (func (export "rmw-sub-i32-seq_cst-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.sub seq_cst $b)
+  (func (export "rmw-sub-i32-acq_rel-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.sub acq_rel $a)
+  (func (export "rmw-sub-i32-acq_rel-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.sub acq_rel $b)
+  (func (export "rmw-and-i32-seq_cst-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.and seq_cst $a)
+  (func (export "rmw-and-i32-seq_cst-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.and seq_cst $b)
+  (func (export "rmw-and-i32-acq_rel-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.and acq_rel $a)
+  (func (export "rmw-and-i32-acq_rel-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.and acq_rel $b)
+  (func (export "rmw-or-i32-seq_cst-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.or seq_cst $a)
+  (func (export "rmw-or-i32-seq_cst-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.or seq_cst $b)
+  (func (export "rmw-or-i32-acq_rel-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.or acq_rel $a)
+  (func (export "rmw-or-i32-acq_rel-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.or acq_rel $b)
+  (func (export "rmw-xor-i32-seq_cst-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.xor seq_cst $a)
+  (func (export "rmw-xor-i32-seq_cst-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.xor seq_cst $b)
+  (func (export "rmw-xor-i32-acq_rel-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.xor acq_rel $a)
+  (func (export "rmw-xor-i32-acq_rel-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.xor acq_rel $b)
+  (func (export "rmw-xchg-i32-seq_cst-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.xchg seq_cst $a)
+  (func (export "rmw-xchg-i32-seq_cst-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.xchg seq_cst $b)
+  (func (export "rmw-xchg-i32-acq_rel-$a") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.xchg acq_rel $a)
+  (func (export "rmw-xchg-i32-acq_rel-$b") (param $x i32) (result i32)
+    local.get $x
+    global.atomic.rmw.xchg acq_rel $b)
+  (func (export "rmw-cmpxchg-i32-seq_cst-$a") (param $x i32) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    global.atomic.rmw.cmpxchg seq_cst $a)
+  (func (export "rmw-cmpxchg-i32-seq_cst-$b") (param $x i32) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    global.atomic.rmw.cmpxchg seq_cst $b)
+  (func (export "rmw-cmpxchg-i32-acq_rel-$a") (param $x i32) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    global.atomic.rmw.cmpxchg acq_rel $a)
+  (func (export "rmw-cmpxchg-i32-acq_rel-$b") (param $x i32) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    global.atomic.rmw.cmpxchg acq_rel $b)
+)
+
+(module (;i64;)
+  (global $a (import "spectest" "global_i64") (shared mut i64))
+  (global $b (shared mut i64) (i64.const 0))
+  (func (export "rmw-add-i64-seq_cst-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.add seq_cst $a)
+  (func (export "rmw-add-i64-seq_cst-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.add seq_cst $b)
+  (func (export "rmw-add-i64-acq_rel-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.add acq_rel $a)
+  (func (export "rmw-add-i64-acq_rel-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.add acq_rel $b)
+  (func (export "rmw-sub-i64-seq_cst-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.sub seq_cst $a)
+  (func (export "rmw-sub-i64-seq_cst-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.sub seq_cst $b)
+  (func (export "rmw-sub-i64-acq_rel-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.sub acq_rel $a)
+  (func (export "rmw-sub-i64-acq_rel-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.sub acq_rel $b)
+  (func (export "rmw-and-i64-seq_cst-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.and seq_cst $a)
+  (func (export "rmw-and-i64-seq_cst-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.and seq_cst $b)
+  (func (export "rmw-and-i64-acq_rel-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.and acq_rel $a)
+  (func (export "rmw-and-i64-acq_rel-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.and acq_rel $b)
+  (func (export "rmw-or-i64-seq_cst-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.or seq_cst $a)
+  (func (export "rmw-or-i64-seq_cst-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.or seq_cst $b)
+  (func (export "rmw-or-i64-acq_rel-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.or acq_rel $a)
+  (func (export "rmw-or-i64-acq_rel-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.or acq_rel $b)
+  (func (export "rmw-xor-i64-seq_cst-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.xor seq_cst $a)
+  (func (export "rmw-xor-i64-seq_cst-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.xor seq_cst $b)
+  (func (export "rmw-xor-i64-acq_rel-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.xor acq_rel $a)
+  (func (export "rmw-xor-i64-acq_rel-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.xor acq_rel $b)
+  (func (export "rmw-xchg-i64-seq_cst-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.xchg seq_cst $a)
+  (func (export "rmw-xchg-i64-seq_cst-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.xchg seq_cst $b)
+  (func (export "rmw-xchg-i64-acq_rel-$a") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.xchg acq_rel $a)
+  (func (export "rmw-xchg-i64-acq_rel-$b") (param $x i64) (result i64)
+    local.get $x
+    global.atomic.rmw.xchg acq_rel $b)
+  (func (export "rmw-cmpxchg-i64-seq_cst-$a") (param $x i64) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    global.atomic.rmw.cmpxchg seq_cst $a)
+  (func (export "rmw-cmpxchg-i64-seq_cst-$b") (param $x i64) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    global.atomic.rmw.cmpxchg seq_cst $b)
+  (func (export "rmw-cmpxchg-i64-acq_rel-$a") (param $x i64) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    global.atomic.rmw.cmpxchg acq_rel $a)
+  (func (export "rmw-cmpxchg-i64-acq_rel-$b") (param $x i64) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    global.atomic.rmw.cmpxchg acq_rel $b)
+)
+
+(assert_invalid
+  (module
+    (global $g (mut funcref) (ref.null func))
+    (func
+      ref.null func
+      global.atomic.rmw.xor acq_rel $g
+      drop
+    )
+  )
+  "invalid type: `global.atomic.rmw.*` only allows `i32` and `i64`")
+
+(assert_invalid
+  (module
+    (func
+      global.atomic.rmw.xor acq_rel 200
+    )
+  )
+  "global index out of bounds")
+
+(assert_invalid
+  (module
+    (global $g (mut funcref) (ref.null func))
+    (func
+      ref.null func
+      global.atomic.rmw.xchg acq_rel $g
+      drop
+    )
+  )
+  "invalid type: `global.atomic.rmw.xchg` only allows `i32`, `i64` and subtypes of `anyref`")
+
+(module
+  (global $g (mut eqref) (ref.null eq))
+  (func
+    ref.null eq
+    global.atomic.rmw.xchg acq_rel $g
+    drop
+  )
+)
+
+(assert_invalid
+  (module
+    (global $g (mut anyref) (ref.null any))
+    (func
+      ref.null any
+      ref.null any
+      global.atomic.rmw.cmpxchg acq_rel $g
+      drop
+    )
+  )
+  "invalid type: `global.atomic.rmw.cmpxchg` only allows `i32`, `i64` and subtypes of `eqref`")
+
+(module
+  (global $g (mut eqref) (ref.null eq))
+  (func
+    ref.null eq
+    ref.null eq
+    global.atomic.rmw.cmpxchg acq_rel $g
+    drop
+  )
+)

--- a/test/core/shared-everything-threads/shared-everything-threads/i31.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/i31.wast
@@ -1,0 +1,230 @@
+(module
+  (func (export "new") (param $i i32) (result (ref (shared i31)))
+    (ref.i31_shared (local.get $i))
+  )
+
+  (func (export "get_u") (param $i i32) (result i32)
+    (i31.get_u (ref.i31_shared (local.get $i)))
+  )
+  (func (export "get_s") (param $i i32) (result i32)
+    (i31.get_s (ref.i31_shared (local.get $i)))
+  )
+
+  (func (export "get_u-null") (result i32)
+    (i31.get_u (ref.null (shared i31)))
+  )
+  (func (export "get_s-null") (result i32)
+    (i31.get_u (ref.null (shared i31)))
+  )
+
+  (global $i (ref (shared i31)) (ref.i31_shared (i32.const 2)))
+  (global $m (mut (ref (shared i31))) (ref.i31_shared (i32.const 3)))
+
+  (func (export "get_globals") (result i32 i32)
+    (i31.get_u (global.get $i))
+    (i31.get_u (global.get $m))
+  )
+
+  (func (export "set_global") (param i32)
+    (global.set $m (ref.i31_shared (local.get 0)))
+  )
+)
+
+(assert_return (invoke "new" (i32.const 1)) (ref.i31_shared))
+
+(assert_return (invoke "get_u" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "get_u" (i32.const 100)) (i32.const 100))
+(assert_return (invoke "get_u" (i32.const -1)) (i32.const 0x7fff_ffff))
+(assert_return (invoke "get_u" (i32.const 0x3fff_ffff)) (i32.const 0x3fff_ffff))
+(assert_return (invoke "get_u" (i32.const 0x4000_0000)) (i32.const 0x4000_0000))
+(assert_return (invoke "get_u" (i32.const 0x7fff_ffff)) (i32.const 0x7fff_ffff))
+(assert_return (invoke "get_u" (i32.const 0xaaaa_aaaa)) (i32.const 0x2aaa_aaaa))
+(assert_return (invoke "get_u" (i32.const 0xcaaa_aaaa)) (i32.const 0x4aaa_aaaa))
+
+(assert_return (invoke "get_s" (i32.const 0)) (i32.const 0))
+(assert_return (invoke "get_s" (i32.const 100)) (i32.const 100))
+(assert_return (invoke "get_s" (i32.const -1)) (i32.const -1))
+(assert_return (invoke "get_s" (i32.const 0x3fff_ffff)) (i32.const 0x3fff_ffff))
+(assert_return (invoke "get_s" (i32.const 0x4000_0000)) (i32.const -0x4000_0000))
+(assert_return (invoke "get_s" (i32.const 0x7fff_ffff)) (i32.const -1))
+(assert_return (invoke "get_s" (i32.const 0xaaaa_aaaa)) (i32.const 0x2aaa_aaaa))
+(assert_return (invoke "get_s" (i32.const 0xcaaa_aaaa)) (i32.const 0xcaaa_aaaa))
+
+(assert_trap (invoke "get_u-null") "null i31 reference")
+(assert_trap (invoke "get_s-null") "null i31 reference")
+
+(assert_return (invoke "get_globals") (i32.const 2) (i32.const 3))
+
+(invoke "set_global" (i32.const 1234))
+(assert_return (invoke "get_globals") (i32.const 2) (i32.const 1234))
+
+(module $tables_of_i31ref
+  (table $table 3 10 (ref null (shared i31)))
+  (elem (table $table) (i32.const 0) (ref null (shared i31))
+      (item (ref.i31_shared (i32.const 999)))
+      (item (ref.i31_shared (i32.const 888)))
+      (item (ref.i31_shared (i32.const 777))))
+
+  (func (export "size") (result i32)
+    table.size $table
+  )
+
+  (func (export "get") (param i32) (result i32)
+    (i31.get_u (table.get $table (local.get 0)))
+  )
+
+  (func (export "grow") (param i32 i32) (result i32)
+    (table.grow $table (ref.i31_shared (local.get 1)) (local.get 0))
+  )
+
+  (func (export "fill") (param i32 i32 i32)
+    (table.fill $table (local.get 0) (ref.i31_shared (local.get 1)) (local.get 2))
+  )
+
+  (func (export "copy") (param i32 i32 i32)
+    (table.copy $table $table (local.get 0) (local.get 1) (local.get 2))
+  )
+
+  (elem $elem (ref null (shared i31)) (item (ref.i31_shared (i32.const 123)))
+                                      (item (ref.i31_shared (i32.const 456)))
+                                      (item (ref.i31_shared (i32.const 789))))
+  (func (export "init") (param i32 i32 i32)
+    (table.init $table $elem (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+
+;; Initial state.
+(assert_return (invoke "size") (i32.const 3))
+(assert_return (invoke "get" (i32.const 0)) (i32.const 999))
+(assert_return (invoke "get" (i32.const 1)) (i32.const 888))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 777))
+
+;; Grow from size 3 to size 5.
+(assert_return (invoke "grow" (i32.const 2) (i32.const 333)) (i32.const 3))
+(assert_return (invoke "size") (i32.const 5))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 333))
+(assert_return (invoke "get" (i32.const 4)) (i32.const 333))
+
+;; Fill table[2..4] = 111.
+(invoke "fill" (i32.const 2) (i32.const 111) (i32.const 2))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 111))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 111))
+
+;; Copy from table[0..2] to table[3..5].
+(invoke "copy" (i32.const 3) (i32.const 0) (i32.const 2))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 999))
+(assert_return (invoke "get" (i32.const 4)) (i32.const 888))
+
+;; Initialize the passive element at table[1..4].
+(invoke "init" (i32.const 1) (i32.const 0) (i32.const 3))
+(assert_return (invoke "get" (i32.const 1)) (i32.const 123))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 456))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 789))
+
+(module $env
+  (global (export "g") i32 (i32.const 42))
+)
+(register "env")
+
+(module $i31ref_of_global_table_initializer
+  (global $g (import "env" "g") i32)
+  (table $t 3 3 (ref (shared i31)) (ref.i31_shared (global.get $g)))
+  (func (export "get") (param i32) (result i32)
+    (i31.get_u (local.get 0) (table.get $t))
+  )
+)
+
+(assert_return (invoke "get" (i32.const 0)) (i32.const 42))
+(assert_return (invoke "get" (i32.const 1)) (i32.const 42))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 42))
+
+(module $i31ref_of_global_global_initializer
+  (global $g0 (import "env" "g") i32)
+  (global $g1 (ref null (shared i31)) (ref.i31_shared (global.get $g0)))
+  (func (export "get") (result i32)
+    (i31.get_u (global.get $g1))
+  )
+)
+
+(assert_return (invoke "get") (i32.const 42))
+
+(module $anyref_global_of_i31ref
+  (global $c (ref null (shared any)) (ref.i31_shared (i32.const 1234)))
+  (global $m (mut (ref null (shared any))) (ref.i31_shared (i32.const 5678)))
+
+  (func (export "get_globals") (result i32 i32)
+    (i31.get_u (ref.cast (ref null (shared i31)) (global.get $c)))
+    (i31.get_u (ref.cast (ref null (shared i31)) (global.get $m)))
+  )
+
+  (func (export "set_global") (param i32)
+    (global.set $m (ref.i31_shared (local.get 0)))
+  )
+)
+
+(assert_return (invoke "get_globals") (i32.const 1234) (i32.const 5678))
+(invoke "set_global" (i32.const 0))
+(assert_return (invoke "get_globals") (i32.const 1234) (i32.const 0))
+
+(module $anyref_table_of_i31ref
+  (table $table 3 10 (ref null (shared any)))
+  (elem (table $table) (i32.const 0) (ref null (shared i31))
+      (item (ref.i31_shared (i32.const 999)))
+      (item (ref.i31_shared (i32.const 888)))
+      (item (ref.i31_shared (i32.const 777))))
+
+  (func (export "size") (result i32)
+    table.size $table
+  )
+
+  (func (export "get") (param i32) (result i32)
+    (i31.get_u (ref.cast (ref null (shared i31)) (table.get $table (local.get 0))))
+  )
+
+  (func (export "grow") (param i32 i32) (result i32)
+    (table.grow $table (ref.i31_shared (local.get 1)) (local.get 0))
+  )
+
+  (func (export "fill") (param i32 i32 i32)
+    (table.fill $table (local.get 0) (ref.i31_shared (local.get 1)) (local.get 2))
+  )
+
+  (func (export "copy") (param i32 i32 i32)
+    (table.copy $table $table (local.get 0) (local.get 1) (local.get 2))
+  )
+
+  (elem $elem (ref null (shared i31)) (item (ref.i31_shared (i32.const 123)))
+                     (item (ref.i31_shared (i32.const 456)))
+                     (item (ref.i31_shared (i32.const 789))))
+  (func (export "init") (param i32 i32 i32)
+    (table.init $table $elem (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+
+;; Initial state.
+(assert_return (invoke "size") (i32.const 3))
+(assert_return (invoke "get" (i32.const 0)) (i32.const 999))
+(assert_return (invoke "get" (i32.const 1)) (i32.const 888))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 777))
+
+;; Grow from size 3 to size 5.
+(assert_return (invoke "grow" (i32.const 2) (i32.const 333)) (i32.const 3))
+(assert_return (invoke "size") (i32.const 5))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 333))
+(assert_return (invoke "get" (i32.const 4)) (i32.const 333))
+
+;; Fill table[2..4] = 111.
+(invoke "fill" (i32.const 2) (i32.const 111) (i32.const 2))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 111))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 111))
+
+;; Copy from table[0..2] to table[3..5].
+(invoke "copy" (i32.const 3) (i32.const 0) (i32.const 2))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 999))
+(assert_return (invoke "get" (i32.const 4)) (i32.const 888))
+
+;; Initialize the passive element at table[1..4].
+(invoke "init" (i32.const 1) (i32.const 0) (i32.const 3))
+(assert_return (invoke "get" (i32.const 1)) (i32.const 123))
+(assert_return (invoke "get" (i32.const 2)) (i32.const 456))
+(assert_return (invoke "get" (i32.const 3)) (i32.const 789))

--- a/test/core/shared-everything-threads/shared-everything-threads/polymorphism.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/polymorphism.wast
@@ -1,0 +1,23 @@
+;; Some instructions are shared-polymorphic and work with shared or unshared
+;; references.
+(module
+  (func (drop (ref.eq (ref.null (shared none)) (ref.null (shared none)))))
+
+  (func (param (ref null (shared i31))) (drop (i31.get_s (local.get 0))))
+  (func (param (ref null (shared i31))) (drop (i31.get_u (local.get 0))))
+
+  (func (param (ref null (shared array))) (drop (array.len (local.get 0))))
+
+  (func (param (ref null (shared extern))) (result (ref null (shared any)))
+    (any.convert_extern (local.get 0))
+  )
+  (func (param (ref (shared extern))) (result (ref (shared any)))
+    (any.convert_extern (local.get 0))
+  )
+  (func (param (ref null (shared any))) (result (ref null (shared extern)))
+    (extern.convert_any (local.get 0))
+  )
+  (func (param (ref (shared any))) (result (ref (shared extern)))
+    (extern.convert_any (local.get 0))
+  )
+)

--- a/test/core/shared-everything-threads/shared-everything-threads/ref-equivalence.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/ref-equivalence.wast
@@ -1,0 +1,202 @@
+(module
+  (type $st (sub (shared (struct))))
+  (type $st' (sub (shared (struct (field i32)))))
+  (type $at (shared (array i8)))
+  (type $st-sub1 (sub $st (shared (struct))))
+  (type $st-sub2 (sub $st (shared (struct))))
+  (type $st'-sub1 (sub $st' (shared (struct (field i32)))))
+  (type $st'-sub2 (sub $st' (shared (struct (field i32)))))
+
+  (table 20 (ref null (shared eq)))
+
+  (func (export "init")
+    (table.set (i32.const 0) (ref.null (shared eq)))
+    (table.set (i32.const 1) (ref.null (shared i31)))
+    (table.set (i32.const 2) (ref.i31_shared (i32.const 7)))
+    (table.set (i32.const 3) (ref.i31_shared (i32.const 7)))
+    (table.set (i32.const 4) (ref.i31_shared (i32.const 8)))
+    (table.set (i32.const 5) (struct.new_default $st))
+    (table.set (i32.const 6) (struct.new_default $st))
+    (table.set (i32.const 7) (array.new_default $at (i32.const 0)))
+    (table.set (i32.const 8) (array.new_default $at (i32.const 0)))
+  )
+
+  (func (export "eq") (param $i i32) (param $j i32) (result i32)
+    (ref.eq (table.get (local.get $i)) (table.get (local.get $j)))
+  )
+)
+
+(invoke "init")
+
+(assert_return (invoke "eq" (i32.const 0) (i32.const 0)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 0) (i32.const 1)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 0) (i32.const 2)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 0) (i32.const 3)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 0) (i32.const 4)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 0) (i32.const 5)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 0) (i32.const 6)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 0) (i32.const 7)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 0) (i32.const 8)) (i32.const 0))
+
+(assert_return (invoke "eq" (i32.const 1) (i32.const 0)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 1) (i32.const 1)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 1) (i32.const 2)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 1) (i32.const 3)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 1) (i32.const 4)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 1) (i32.const 5)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 1) (i32.const 6)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 1) (i32.const 7)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 1) (i32.const 8)) (i32.const 0))
+
+(assert_return (invoke "eq" (i32.const 2) (i32.const 0)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 2) (i32.const 1)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 2) (i32.const 2)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 2) (i32.const 3)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 2) (i32.const 4)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 2) (i32.const 5)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 2) (i32.const 6)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 2) (i32.const 7)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 2) (i32.const 8)) (i32.const 0))
+
+(assert_return (invoke "eq" (i32.const 3) (i32.const 0)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 3) (i32.const 1)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 3) (i32.const 2)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 3) (i32.const 3)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 3) (i32.const 4)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 3) (i32.const 5)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 3) (i32.const 6)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 3) (i32.const 7)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 3) (i32.const 8)) (i32.const 0))
+
+(assert_return (invoke "eq" (i32.const 4) (i32.const 0)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 4) (i32.const 1)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 4) (i32.const 2)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 4) (i32.const 3)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 4) (i32.const 4)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 4) (i32.const 5)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 4) (i32.const 6)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 4) (i32.const 7)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 4) (i32.const 8)) (i32.const 0))
+
+(assert_return (invoke "eq" (i32.const 5) (i32.const 0)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 5) (i32.const 1)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 5) (i32.const 2)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 5) (i32.const 3)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 5) (i32.const 4)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 5) (i32.const 5)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 5) (i32.const 6)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 5) (i32.const 7)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 5) (i32.const 8)) (i32.const 0))
+
+(assert_return (invoke "eq" (i32.const 6) (i32.const 0)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 6) (i32.const 1)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 6) (i32.const 2)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 6) (i32.const 3)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 6) (i32.const 4)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 6) (i32.const 5)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 6) (i32.const 6)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 6) (i32.const 7)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 6) (i32.const 8)) (i32.const 0))
+
+(assert_return (invoke "eq" (i32.const 7) (i32.const 0)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 7) (i32.const 1)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 7) (i32.const 2)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 7) (i32.const 3)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 7) (i32.const 4)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 7) (i32.const 5)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 7) (i32.const 6)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 7) (i32.const 7)) (i32.const 1))
+(assert_return (invoke "eq" (i32.const 7) (i32.const 8)) (i32.const 0))
+
+(assert_return (invoke "eq" (i32.const 8) (i32.const 0)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 8) (i32.const 1)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 8) (i32.const 2)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 8) (i32.const 3)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 8) (i32.const 4)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 8) (i32.const 5)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 8) (i32.const 6)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 8) (i32.const 7)) (i32.const 0))
+(assert_return (invoke "eq" (i32.const 8) (i32.const 8)) (i32.const 1))
+
+(assert_invalid
+  (module
+    (func (export "eq") (param $r (ref (shared any))) (result i32)
+      (ref.eq (local.get $r) (local.get $r))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (export "eq") (param $r (ref null (shared any))) (result i32)
+      (ref.eq (local.get $r) (local.get $r))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (export "eq") (param $r (ref null (shared func))) (result i32)
+      (ref.eq (local.get $r) (local.get $r))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (export "eq") (param $r (ref null (shared func))) (result i32)
+      (ref.eq (local.get $r) (local.get $r))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (export "eq") (param $r (ref (shared extern))) (result i32)
+      (ref.eq (local.get $r) (local.get $r))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (export "eq") (param $r (ref null (shared extern))) (result i32)
+      (ref.eq (local.get $r) (local.get $r))
+    )
+  )
+  "type mismatch"
+)
+
+;; Mixed shared / unshared eq
+(assert_invalid
+  (module
+    (func (export "eq") (param $r1 (ref eq)) (param $r2 (ref (shared eq))) (result i32)
+      (ref.eq (local.get $r1) (local.get $r2))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (export "eq") (param $r1 (ref (shared eq))) (param $r2 (ref eq)) (result i32)
+      (ref.eq (local.get $r1) (local.get $r2))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (export "eq") (param $r1 eqref) (param $r2 (ref null (shared eq))) (result i32)
+      (ref.eq (local.get $r1) (local.get $r2))
+    )
+  )
+  "type mismatch"
+)
+(assert_invalid
+  (module
+    (func (export "eq") (param $r1 (ref null (shared eq))) (param $r2 eqref) (result i32)
+      (ref.eq (local.get $r1) (local.get $r2))
+    )
+  )
+  "type mismatch"
+)

--- a/test/core/shared-everything-threads/shared-everything-threads/structs.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/structs.wast
@@ -1,0 +1,572 @@
+;; Shared struct declaration syntax.
+(module
+  (type (shared (struct)))
+  (type (sub final (shared (struct))))
+  (rec
+    (type (sub final (shared (struct))))
+  )
+
+  (global (ref 0) (struct.new 1))
+  (global (ref 1) (struct.new 2))
+  (global (ref 2) (struct.new 0))
+)
+
+;; Shared structs are distinct from non-shared structs.
+(assert_invalid
+  (module
+    (type (shared (struct)))
+    (type (struct))
+
+    (global (ref 0) (struct.new 1))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type (shared (struct)))
+    (type (struct))
+
+    (global (ref 1) (struct.new 0))
+  )
+  "type mismatch"
+)
+
+;; Shared structs may not be subtypes of non-shared structs.
+(assert_invalid
+  (module
+    (type (sub (struct)))
+    (type (sub 0 (shared (struct))))
+  )
+  "must match super type"
+)
+
+;; Non-shared structs may not be subtypes of shared structs.
+(assert_invalid
+  (module
+    (type (sub (shared (struct))))
+    (type (sub 0 (struct)))
+  )
+  "must match super type"
+)
+
+;; Shared structs may not contain non-shared references.
+(assert_invalid
+  (module
+    (type (shared (struct (field anyref))))
+  )
+  "must contain shared type"
+)
+
+;; But they may contain shared references.
+(module
+  (type (shared (struct (field (ref null (shared any))))))
+)
+
+;; Non-shared structs may contain shared references.
+(module
+  (type (struct (field (ref null (shared any)))))
+)
+
+;; Struct instructions work on shared structs.
+(module
+  (type $i8 (shared (struct (field (mut i8)))))
+  (type $i32 (shared (struct (field (mut i32)))))
+  (type $unshared (struct (field (mut i8))))
+
+  (func (struct.new $i8 (i32.const 0)) (drop))
+
+  (func (struct.new_default $i8) (drop))
+
+  (func (param (ref null $i8))
+    (struct.get_s $i8 0 (local.get 0)) (drop))
+
+  (func (param (ref null $i8))
+    (struct.get_u $i8 0 (local.get 0)) (drop))
+
+  (func (param (ref null $i32))
+    (struct.get $i32 0 (local.get 0)) (drop))
+
+  (func (param (ref null $i8))
+    (struct.set $i8 0 (local.get 0) (i32.const 0)))
+)
+
+;; Bottom types can be used as shared structs.
+(module
+  (type $i8 (shared (struct (field (mut i8)))))
+  (func (drop (struct.get_s $i8 0 (ref.null (shared none)))))
+  (func (drop (struct.get_u $i8 0 (ref.null (shared none)))))
+  (func (struct.set $i8 0 (ref.null (shared none)) (i32.const 0)))
+)
+
+;; Check that field-modifying instructions only work on mutable fields.
+(assert_invalid
+  (module
+    (type $s (shared (struct (field (ref (shared any))))))
+    (func (param $s (ref $s)) (param $a (ref (shared any))) (result (ref (shared any)))
+      (struct.atomic.set seq_cst $s 0 (local.get $s) (local.get $a))
+    )
+  )
+  "field is immutable"
+)
+(assert_invalid
+  (module
+    (type $s (shared (struct (field i32))))
+    (func (param $s (ref $s)) (result i32)
+      (struct.atomic.rmw.add seq_cst $s 0 (local.get $s) (i32.const 1))
+    )
+  )
+  "field is immutable"
+)
+(assert_invalid
+  (module
+    (type $s (shared (struct (field i64))))
+    (func (param $s (ref $s)) (result i64)
+      (struct.atomic.rmw.sub seq_cst $s 0 (local.get $s) (i64.const 1))
+    )
+  )
+  "field is immutable"
+)
+(assert_invalid
+  (module
+    (type $s (shared (struct (field i32))))
+    (func (param $s (ref $s)) (result i32)
+      (struct.atomic.rmw.and acq_rel $s 0 (local.get $s) (i32.const 1))
+    )
+  )
+  "field is immutable"
+)
+(assert_invalid
+  (module
+    (type $s (shared (struct (field i64))))
+    (func (param $s (ref $s)) (result i64)
+      (struct.atomic.rmw.or acq_rel $s 0 (local.get $s) (i64.const 1))
+    )
+  )
+  "field is immutable"
+)
+(assert_invalid
+  (module
+    (type $s (shared (struct (field i32))))
+    (func (param $s (ref $s)) (result i32)
+      (struct.atomic.rmw.xor seq_cst $s 0 (local.get $s) (i32.const 1))
+    )
+  )
+  "field is immutable"
+)
+(assert_invalid
+  (module
+    (type $s (shared (struct (field (ref (shared any))))))
+    (func (param $s (ref $s)) (param $a (ref (shared any))) (result (ref (shared any)))
+      (struct.atomic.rmw.xchg seq_cst $s 0 (local.get $s) (local.get $a))
+    )
+  )
+  "field is immutable"
+)
+(assert_invalid
+  (module
+    (type $s (shared (struct (field (ref (shared eq))))))
+    (func (param $s (ref $s)) (param $e1 (ref (shared eq))) (param $e2 (ref (shared eq))) (result (ref (shared eq)))
+      (struct.atomic.rmw.cmpxchg acq_rel $s 0 (local.get $s) (local.get $e1) (local.get $e2))
+    )
+  )
+  "field is immutable"
+)
+
+;; Exhaustively check `struct.atomic.rmw.*` instructions.
+(module
+  (type $s (shared (struct
+    (field $i8 (mut i8))
+    (field $i16 (mut i16))
+    (field $i32 (mut i32))
+    (field $i64 (mut i64))
+    (field $anyref (mut (ref null (shared any))))
+    (field $eqref (mut (ref null (shared eq)))))))
+  (func (export "struct-atomic-get-i32-seq_cst") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get seq_cst $s $i32)
+  (func (export "struct-atomic-get-i64-seq_cst") (param $x (ref null $s)) (result i64)
+    local.get $x
+    struct.atomic.get seq_cst $s $i64)
+  (func (export "struct-atomic-get-anyref-seq_cst") (param $x (ref null $s)) (result (ref null (shared any)))
+    local.get $x
+    struct.atomic.get seq_cst $s $anyref)
+  (func (export "struct-atomic-get-i32-acq_rel") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get acq_rel $s $i32)
+  (func (export "struct-atomic-get-i64-acq_rel") (param $x (ref null $s)) (result i64)
+    local.get $x
+    struct.atomic.get acq_rel $s $i64)
+  (func (export "struct-atomic-get-anyref-acq_rel") (param $x (ref null $s)) (result (ref null (shared any)))
+    local.get $x
+    struct.atomic.get acq_rel $s $anyref)
+  (func (export "struct-atomic-get_s-i8-seq_cst") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_s seq_cst $s $i8)
+  (func (export "struct-atomic-get_s-i16-seq_cst") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_s seq_cst $s $i16)
+  (func (export "struct-atomic-get_s-i8-acq_rel") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_s acq_rel $s $i8)
+  (func (export "struct-atomic-get_s-i16-acq_rel") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_s acq_rel $s $i16)
+  (func (export "struct-atomic-get_u-i8-seq_cst") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_u seq_cst $s $i8)
+  (func (export "struct-atomic-get_u-i16-seq_cst") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_u seq_cst $s $i16)
+  (func (export "struct-atomic-get_u-i8-acq_rel") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_u acq_rel $s $i8)
+  (func (export "struct-atomic-get_u-i16-acq_rel") (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_u acq_rel $s $i16)
+  (func (export "struct-atomic-set-i8-seq_cst") (param $x (ref null $s)) (param $y i32)
+    local.get $x
+    local.get $y
+    struct.atomic.set seq_cst $s $i8)
+  (func (export "struct-atomic-set-i16-seq_cst") (param $x (ref null $s)) (param $y i32)
+    local.get $x
+    local.get $y
+    struct.atomic.set seq_cst $s $i16)
+  (func (export "struct-atomic-set-i32-seq_cst") (param $x (ref null $s)) (param $y i32)
+    local.get $x
+    local.get $y
+    struct.atomic.set seq_cst $s $i32)
+  (func (export "struct-atomic-set-i64-seq_cst") (param $x (ref null $s)) (param $y i64)
+    local.get $x
+    local.get $y
+    struct.atomic.set seq_cst $s $i64)
+  (func (export "struct-atomic-set-anyref-seq_cst") (param $x (ref null $s)) (param $y (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.set seq_cst $s $anyref)
+  (func (export "struct-atomic-set-i8-acq_rel") (param $x (ref null $s)) (param $y i32)
+    local.get $x
+    local.get $y
+    struct.atomic.set acq_rel $s $i8)
+  (func (export "struct-atomic-set-i16-acq_rel") (param $x (ref null $s)) (param $y i32)
+    local.get $x
+    local.get $y
+    struct.atomic.set acq_rel $s $i16)
+  (func (export "struct-atomic-set-i32-acq_rel") (param $x (ref null $s)) (param $y i32)
+    local.get $x
+    local.get $y
+    struct.atomic.set acq_rel $s $i32)
+  (func (export "struct-atomic-set-i64-acq_rel") (param $x (ref null $s)) (param $y i64)
+    local.get $x
+    local.get $y
+    struct.atomic.set acq_rel $s $i64)
+  (func (export "struct-atomic-set-anyref-acq_rel") (param $x (ref null $s)) (param $y (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.set acq_rel $s $anyref)
+  (func (export "struct-atomic-rmw.add-i32-seq_cst") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.add seq_cst $s $i32)
+  (func (export "struct-atomic-rmw.add-i64-seq_cst") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.add seq_cst $s $i64)
+  (func (export "struct-atomic-rmw.add-i32-acq_rel") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.add acq_rel $s $i32)
+  (func (export "struct-atomic-rmw.add-i64-acq_rel") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.add acq_rel $s $i64)
+  (func (export "struct-atomic-rmw.sub-i32-seq_cst") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.sub seq_cst $s $i32)
+  (func (export "struct-atomic-rmw.sub-i64-seq_cst") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.sub seq_cst $s $i64)
+  (func (export "struct-atomic-rmw.sub-i32-acq_rel") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.sub acq_rel $s $i32)
+  (func (export "struct-atomic-rmw.sub-i64-acq_rel") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.sub acq_rel $s $i64)
+  (func (export "struct-atomic-rmw.and-i32-seq_cst") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.and seq_cst $s $i32)
+  (func (export "struct-atomic-rmw.and-i64-seq_cst") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.and seq_cst $s $i64)
+  (func (export "struct-atomic-rmw.and-i32-acq_rel") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.and acq_rel $s $i32)
+  (func (export "struct-atomic-rmw.and-i64-acq_rel") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.and acq_rel $s $i64)
+  (func (export "struct-atomic-rmw.or-i32-seq_cst") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.or seq_cst $s $i32)
+  (func (export "struct-atomic-rmw.or-i64-seq_cst") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.or seq_cst $s $i64)
+  (func (export "struct-atomic-rmw.or-i32-acq_rel") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.or acq_rel $s $i32)
+  (func (export "struct-atomic-rmw.or-i64-acq_rel") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.or acq_rel $s $i64)
+  (func (export "struct-atomic-rmw.xor-i32-seq_cst") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xor seq_cst $s $i32)
+  (func (export "struct-atomic-rmw.xor-i64-seq_cst") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xor seq_cst $s $i64)
+  (func (export "struct-atomic-rmw.xor-i32-acq_rel") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xor acq_rel $s $i32)
+  (func (export "struct-atomic-rmw.xor-i64-acq_rel") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xor acq_rel $s $i64)
+  (func (export "struct-atomic-rmw.xchg-i32-seq_cst") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xchg seq_cst $s $i32)
+  (func (export "struct-atomic-rmw.xchg-i64-seq_cst") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xchg seq_cst $s $i64)
+  (func (export "struct-atomic-rmw.xchg-anyref-seq_cst") (param $x (ref null $s)) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xchg seq_cst $s $anyref)
+  (func (export "struct-atomic-rmw.xchg-i32-acq_rel") (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xchg acq_rel $s $i32)
+  (func (export "struct-atomic-rmw.xchg-i64-acq_rel") (param $x (ref null $s)) (param $y i64) (result i64)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xchg acq_rel $s $i64)
+  (func (export "struct-atomic-rmw.xchg-anyref-acq_rel") (param $x (ref null $s)) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xchg acq_rel $s $anyref)
+  (func (export "struct-atomic-rmw.cmpxchg-i32-seq_cst") (param $x (ref null $s)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    struct.atomic.rmw.cmpxchg seq_cst $s $i32)
+  (func (export "struct-atomic-rmw.cmpxchg-i64-seq_cst") (param $x (ref null $s)) (param $y i64) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    struct.atomic.rmw.cmpxchg seq_cst $s $i64)
+  (func (export "struct-atomic-rmw.cmpxchg-eqref-seq_cst") (param $x (ref null $s)) (param $y (ref null (shared eq))) (param $z (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    local.get $z
+    struct.atomic.rmw.cmpxchg seq_cst $s $eqref)
+  (func (export "struct-atomic-rmw.cmpxchg-i32-acq_rel") (param $x (ref null $s)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    struct.atomic.rmw.cmpxchg acq_rel $s $i32)
+  (func (export "struct-atomic-rmw.cmpxchg-i64-acq_rel") (param $x (ref null $s)) (param $y i64) (param $z i64) (result i64)
+    local.get $x
+    local.get $y
+    local.get $z
+    struct.atomic.rmw.cmpxchg acq_rel $s $i64)
+  (func (export "struct-atomic-rmw.cmpxchg-eqref-acq_rel") (param $x (ref null $s)) (param $y (ref null (shared eq))) (param $z (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    local.get $z
+    struct.atomic.rmw.cmpxchg acq_rel $s $eqref)
+)
+
+(assert_invalid (; get, i8 ;)
+  (module
+    (type $s (shared (struct (field $i8 (mut i8)))))
+  (func (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get seq_cst $s $i8)
+  )
+  "non-packed storage type"
+)
+(assert_invalid (; get_s, i32 ;)
+  (module
+    (type $s (shared (struct (field $i32 (mut i32)))))
+  (func (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_s seq_cst $s $i32)
+  )
+  "non-packed storage types"
+)
+(assert_invalid (; get_s, anyref ;)
+  (module
+    (type $s (shared (struct (field $anyref (mut (ref null (shared any)))))))
+  (func (param $x (ref null $s)) (result (ref null (shared any)))
+    local.get $x
+    struct.atomic.get_s seq_cst $s $anyref)
+  )
+  "non-packed storage types"
+)
+(assert_invalid (; get_u, i32 ;)
+  (module
+    (type $s (shared (struct (field $i32 (mut i32)))))
+  (func (param $x (ref null $s)) (result i32)
+    local.get $x
+    struct.atomic.get_u seq_cst $s $i32)
+  )
+  "non-packed storage types"
+)
+(assert_invalid (; get_u, anyref ;)
+  (module
+    (type $s (shared (struct (field $anyref (mut (ref null (shared any)))))))
+  (func (param $x (ref null $s)) (result (ref null (shared any)))
+    local.get $x
+    struct.atomic.get_u seq_cst $s $anyref)
+  )
+  "non-packed storage types"
+)
+(assert_invalid (; rmw.add, anyref ;)
+  (module
+    (type $s (shared (struct (field $anyref (mut (ref null (shared any)))))))
+  (func (param $x (ref null $s)) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.add seq_cst $s $anyref)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.sub, anyref ;)
+  (module
+    (type $s (shared (struct (field $anyref (mut (ref null (shared any)))))))
+  (func (param $x (ref null $s)) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.sub seq_cst $s $anyref)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.and, anyref ;)
+  (module
+    (type $s (shared (struct (field $anyref (mut (ref null (shared any)))))))
+  (func (param $x (ref null $s)) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.and seq_cst $s $anyref)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.or, anyref ;)
+  (module
+    (type $s (shared (struct (field $anyref (mut (ref null (shared any)))))))
+  (func (param $x (ref null $s)) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.or seq_cst $s $anyref)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.xor, anyref ;)
+  (module
+    (type $s (shared (struct (field $anyref (mut (ref null (shared any)))))))
+  (func (param $x (ref null $s)) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xor seq_cst $s $anyref)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.xchg, i8 ;)
+  (module
+    (type $s (shared (struct (field $i8 (mut i8)))))
+  (func (param $x (ref null $s)) (param $y i32) (result i32)
+    local.get $x
+    local.get $y
+    struct.atomic.rmw.xchg seq_cst $s $i8)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.cmpxchg, i8 ;)
+  (module
+    (type $s (shared (struct (field $i8 (mut i8)))))
+  (func (param $x (ref null $s)) (param $y i32) (param $z i32) (result i32)
+    local.get $x
+    local.get $y
+    local.get $z
+    struct.atomic.rmw.cmpxchg seq_cst $s $i8)
+  )
+  "invalid type"
+)
+(assert_invalid (; rmw.cmpxchg, anyref ;)
+  (module
+    (type $s (shared (struct (field $anyref (mut (ref null (shared any)))))))
+  (func (param $x (ref null $s)) (param $y (ref null (shared any))) (param $z (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    local.get $z
+    struct.atomic.rmw.cmpxchg seq_cst $s $anyref)
+  )
+  "invalid type"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (struct (field $f f32))))
+    (func
+      unreachable
+      struct.atomic.get seq_cst $s $f
+      drop
+    ))
+  "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (struct (field $f (ref (shared func))))))
+    (func
+      unreachable
+      struct.atomic.get seq_cst $s $f
+      drop
+    ))
+  "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (struct (field $f i8))))
+    (func
+      unreachable
+      struct.atomic.get seq_cst $s $f
+      drop
+    ))
+  "can only use struct `get` with non-packed storage types"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (struct (field $f (mut (ref (shared extern)))))))
+    (func
+      unreachable
+      struct.atomic.set seq_cst $s $f
+    ))
+  "invalid type: `struct.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`"
+)

--- a/test/core/shared-everything-threads/shared-everything-threads/tables.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/tables.wast
@@ -1,0 +1,206 @@
+;; Check the `shared` attribute on tables.
+
+(module
+  ;; Imported.
+  (table (import "spectest" "table_ref") shared 1 (ref null (shared func)))
+  (table (import "spectest" "table_ref_with_max") shared 1 1 (ref null (shared func)))
+
+  ;; Normal.
+  (table shared 1 (ref null (shared func)))
+  (table shared 1 1 (ref null (shared func)))
+
+  ;; Inlined.
+  (table shared (ref null (shared func)) (elem (ref.null (shared func))))
+)
+
+;; Note that shared elements can live within an unshared table.
+(module
+  (table (import "spectest" "table_ref") 1 (ref null (shared func)))
+)
+
+(assert_malformed
+  (module quote "(table 1 shared funcref)")
+  "unexpected token")
+
+(assert_malformed
+  (module quote "(table 1 funcref shared)")
+  "unexpected token")
+
+;; The proposal creates too much ambiguity to allow this syntax: the parser
+;; would need to lookahead multiple tokens.
+(assert_malformed
+  (module quote "(table shared i64 (ref null (shared func)) (elem (ref.null (shared func))))")
+  "expected a u64")
+
+(assert_invalid
+  (module (table (import "spectest" "table_ref") shared 0 funcref))
+  "shared tables must have a shared element type")
+
+(assert_invalid
+  (module
+    (type $t (func))
+    (table shared 0 (ref $t)))
+  "shared tables must have a shared element type")
+
+;; Check `table.atomic.*` instructions.
+(module (;eq;)
+  (table $a (import "spectest" "table_eq") shared 1 (ref null (shared eq)))
+  (table $b shared 1 (ref null (shared eq)))
+  (func (export "table-atomic-get-eq-seq_cst-$a") (param $x i32) (result (ref null (shared eq)))
+    local.get $x
+    table.atomic.get seq_cst $a)
+  (func (export "table-atomic-get-eq-seq_cst-$b") (param $x i32) (result (ref null (shared eq)))
+    local.get $x
+    table.atomic.get seq_cst $b)
+  (func (export "table-atomic-get-eq-acq_rel-$a") (param $x i32) (result (ref null (shared eq)))
+    local.get $x
+    table.atomic.get acq_rel $a)
+  (func (export "table-atomic-get-eq-acq_rel-$b") (param $x i32) (result (ref null (shared eq)))
+    local.get $x
+    table.atomic.get acq_rel $b)
+  (func (export "table-atomic-set-eq-seq_cst-$a") (param $x i32) (param $y (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    table.atomic.set seq_cst $a)
+  (func (export "table-atomic-set-eq-seq_cst-$b") (param $x i32) (param $y (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    table.atomic.set seq_cst $b)
+  (func (export "table-atomic-set-eq-acq_rel-$a") (param $x i32) (param $y (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    table.atomic.set acq_rel $a)
+  (func (export "table-atomic-set-eq-acq_rel-$b") (param $x i32) (param $y (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    table.atomic.set acq_rel $b)
+  (func (export "table-atomic-rmw.xchg-eq-seq_cst-$a") (param $x i32) (param $y (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    table.atomic.rmw.xchg seq_cst $a)
+  (func (export "table-atomic-rmw.xchg-eq-seq_cst-$b") (param $x i32) (param $y (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    table.atomic.rmw.xchg seq_cst $b)
+  (func (export "table-atomic-rmw.xchg-eq-acq_rel-$a") (param $x i32) (param $y (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    table.atomic.rmw.xchg acq_rel $a)
+  (func (export "table-atomic-rmw.xchg-eq-acq_rel-$b") (param $x i32) (param $y (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    table.atomic.rmw.xchg acq_rel $b)
+  (func (export "table-atomic-rmw.cmpxchg-eq-seq_cst-$a") (param $x i32) (param $y (ref null (shared eq))) (param $z (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    local.get $z
+    table.atomic.rmw.cmpxchg seq_cst $a)
+  (func (export "table-atomic-rmw.cmpxchg-eq-seq_cst-$b") (param $x i32) (param $y (ref null (shared eq))) (param $z (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    local.get $z
+    table.atomic.rmw.cmpxchg seq_cst $b)
+  (func (export "table-atomic-rmw.cmpxchg-eq-acq_rel-$a") (param $x i32) (param $y (ref null (shared eq))) (param $z (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    local.get $z
+    table.atomic.rmw.cmpxchg acq_rel $a)
+  (func (export "table-atomic-rmw.cmpxchg-eq-acq_rel-$b") (param $x i32) (param $y (ref null (shared eq))) (param $z (ref null (shared eq))) (result (ref null (shared eq)))
+    local.get $x
+    local.get $y
+    local.get $z
+    table.atomic.rmw.cmpxchg acq_rel $b)
+)
+
+(module (;any;)
+  (table $a (import "spectest" "table_any") shared 1 (ref null (shared any)))
+  (table $b shared 1 (ref null (shared any)))
+  (func (export "table-atomic-get-any-seq_cst-$a") (param $x i32) (result (ref null (shared any)))
+    local.get $x
+    table.atomic.get seq_cst $a)
+  (func (export "table-atomic-get-any-seq_cst-$b") (param $x i32) (result (ref null (shared any)))
+    local.get $x
+    table.atomic.get seq_cst $b)
+  (func (export "table-atomic-get-any-acq_rel-$a") (param $x i32) (result (ref null (shared any)))
+    local.get $x
+    table.atomic.get acq_rel $a)
+  (func (export "table-atomic-get-any-acq_rel-$b") (param $x i32) (result (ref null (shared any)))
+    local.get $x
+    table.atomic.get acq_rel $b)
+  (func (export "table-atomic-set-any-seq_cst-$a") (param $x i32) (param $y (ref null (shared any)))
+    local.get $x
+    local.get $y
+    table.atomic.set seq_cst $a)
+  (func (export "table-atomic-set-any-seq_cst-$b") (param $x i32) (param $y (ref null (shared any)))
+    local.get $x
+    local.get $y
+    table.atomic.set seq_cst $b)
+  (func (export "table-atomic-set-any-acq_rel-$a") (param $x i32) (param $y (ref null (shared any)))
+    local.get $x
+    local.get $y
+    table.atomic.set acq_rel $a)
+  (func (export "table-atomic-set-any-acq_rel-$b") (param $x i32) (param $y (ref null (shared any)))
+    local.get $x
+    local.get $y
+    table.atomic.set acq_rel $b)
+  (func (export "table-atomic-rmw.xchg-any-seq_cst-$a") (param $x i32) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    table.atomic.rmw.xchg seq_cst $a)
+  (func (export "table-atomic-rmw.xchg-any-seq_cst-$b") (param $x i32) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    table.atomic.rmw.xchg seq_cst $b)
+  (func (export "table-atomic-rmw.xchg-any-acq_rel-$a") (param $x i32) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    table.atomic.rmw.xchg acq_rel $a)
+  (func (export "table-atomic-rmw.xchg-any-acq_rel-$b") (param $x i32) (param $y (ref null (shared any))) (result (ref null (shared any)))
+    local.get $x
+    local.get $y
+    table.atomic.rmw.xchg acq_rel $b)
+  ;; table.atomic.rmw.cmpxchg only works with subtypes of eqref.
+)
+
+;; Check that cmpxchg only works with eqref subtypes.
+(assert_invalid
+  (module
+    (table $a shared 0 (ref null (shared any)))
+    (func (param $x i32) (param $y (ref null (shared any))) (param $z (ref null (shared any))) (result (ref null (shared any)))
+      local.get $x
+      local.get $y
+      local.get $z
+      table.atomic.rmw.cmpxchg seq_cst $a))
+  "invalid type")
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (func
+      i32.const 0
+      table.atomic.get seq_cst 0
+    )
+  )
+  "invalid type: `table.atomic.get` only allows subtypes of `anyref`")
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (func
+      i32.const 0
+      ref.null func
+      table.atomic.set seq_cst 0
+    )
+  )
+  "invalid type: `table.atomic.set` only allows subtypes of `anyref`")
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (func
+      i32.const 0
+      ref.null func
+      table.atomic.rmw.xchg seq_cst 0
+    )
+  )
+  "invalid type: `table.atomic.rmw.xchg` only allows subtypes of `anyref`")

--- a/test/core/shared-everything-threads/shared-everything-threads/types.wast
+++ b/test/core/shared-everything-threads/shared-everything-threads/types.wast
@@ -1,0 +1,386 @@
+;; `func` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_funcref") (shared (shared funcref)))
+  (global (import "spectest" "global_mut_funcref") (shared mut (shared funcref)))
+  (global (import "spectest" "global_ref_null_func") (shared (ref null (shared func))))
+  (global (import "spectest" "global_mut_ref_null_func") (shared mut (ref null (shared func))))
+  (global (import "spectest" "global_ref_func") (shared (ref (shared func))))
+  (global (import "spectest" "global_mut_ref_func") (shared mut (ref (shared func))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared funcref)) (ref.null (shared func)))
+  (global (shared (ref null (shared func))) (ref.null (shared func)))
+)
+
+(assert_invalid
+  (module (global (shared funcref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null func))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared func))))
+  "type mismatch")
+
+;; `extern` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_externref") (shared (shared externref)))
+  (global (import "spectest" "global_mut_externref") (shared mut (shared externref)))
+  (global (import "spectest" "global_ref_null_extern") (shared (ref null (shared extern))))
+  (global (import "spectest" "global_mut_ref_null_extern") (shared mut (ref null (shared extern))))
+  (global (import "spectest" "global_ref_extern") (shared (ref (shared extern))))
+  (global (import "spectest" "global_mut_ref_extern") (shared mut (ref (shared extern))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared externref)) (ref.null (shared extern)))
+  (global (shared (ref null (shared extern))) (ref.null (shared extern)))
+)
+
+(assert_invalid
+  (module (global (shared externref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null extern))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared extern))))
+  "type mismatch")
+
+;; `exn` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_exnref") (shared (shared exnref)))
+  (global (import "spectest" "global_mut_exnref") (shared mut (shared exnref)))
+  (global (import "spectest" "global_ref_null_exn") (shared (ref null (shared exn))))
+  (global (import "spectest" "global_mut_ref_null_exn") (shared mut (ref null (shared exn))))
+  (global (import "spectest" "global_ref_exn") (shared (ref (shared exn))))
+  (global (import "spectest" "global_mut_ref_exn") (shared mut (ref (shared exn))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared exnref)) (ref.null (shared exn)))
+  (global (shared (ref null (shared exn))) (ref.null (shared exn)))
+)
+
+(assert_invalid
+  (module (global (shared exnref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null exn))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared exn))))
+  "type mismatch")
+
+;; `any` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_anyref") (shared (shared anyref)))
+  (global (import "spectest" "global_mut_anyref") (shared mut (shared anyref)))
+  (global (import "spectest" "global_ref_null_any") (shared (ref null (shared any))))
+  (global (import "spectest" "global_mut_ref_null_any") (shared mut (ref null (shared any))))
+  (global (import "spectest" "global_ref_any") (shared (ref (shared any))))
+  (global (import "spectest" "global_mut_ref_any") (shared mut (ref (shared any))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared anyref)) (ref.null (shared any)))
+  (global (shared (ref null (shared any))) (ref.null (shared any)))
+)
+
+(assert_invalid
+  (module (global (shared anyref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null any))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared any))))
+  "type mismatch")
+
+;; `eq` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_eqref") (shared (shared eqref)))
+  (global (import "spectest" "global_mut_eqref") (shared mut (shared eqref)))
+  (global (import "spectest" "global_ref_null_eq") (shared (ref null (shared eq))))
+  (global (import "spectest" "global_mut_ref_null_eq") (shared mut (ref null (shared eq))))
+  (global (import "spectest" "global_ref_eq") (shared (ref (shared eq))))
+  (global (import "spectest" "global_mut_ref_eq") (shared mut (ref (shared eq))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared eqref)) (ref.null (shared eq)))
+  (global (shared (ref null (shared eq))) (ref.null (shared eq)))
+)
+
+(assert_invalid
+  (module (global (shared eqref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null eq))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared eq))))
+  "type mismatch")
+
+;; `struct` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_structref") (shared (shared structref)))
+  (global (import "spectest" "global_mut_structref") (shared mut (shared structref)))
+  (global (import "spectest" "global_ref_null_struct") (shared (ref null (shared struct))))
+  (global (import "spectest" "global_mut_ref_null_struct") (shared mut (ref null (shared struct))))
+  (global (import "spectest" "global_ref_struct") (shared (ref (shared struct))))
+  (global (import "spectest" "global_mut_ref_struct") (shared mut (ref (shared struct))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared structref)) (ref.null (shared struct)))
+  (global (shared (ref null (shared struct))) (ref.null (shared struct)))
+)
+
+(assert_invalid
+  (module (global (shared structref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null struct))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared struct))))
+  "type mismatch")
+
+;; `array` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_arrayref") (shared (shared arrayref)))
+  (global (import "spectest" "global_mut_arrayref") (shared mut (shared arrayref)))
+  (global (import "spectest" "global_ref_null_array") (shared (ref null (shared array))))
+  (global (import "spectest" "global_mut_ref_null_array") (shared mut (ref null (shared array))))
+  (global (import "spectest" "global_ref_array") (shared (ref (shared array))))
+  (global (import "spectest" "global_mut_ref_array") (shared mut (ref (shared array))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared arrayref)) (ref.null (shared array)))
+  (global (shared (ref null (shared array))) (ref.null (shared array)))
+)
+
+(assert_invalid
+  (module (global (shared arrayref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null array))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared array))))
+  "type mismatch")
+
+;; `i31` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_i31ref") (shared (shared i31ref)))
+  (global (import "spectest" "global_mut_i31ref") (shared mut (shared i31ref)))
+  (global (import "spectest" "global_ref_null_i31") (shared (ref null (shared i31))))
+  (global (import "spectest" "global_mut_ref_null_i31") (shared mut (ref null (shared i31))))
+  (global (import "spectest" "global_ref_i31") (shared (ref (shared i31))))
+  (global (import "spectest" "global_mut_ref_i31") (shared mut (ref (shared i31))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared i31ref)) (ref.null (shared i31)))
+  (global (shared (ref null (shared i31))) (ref.null (shared i31)))
+)
+
+(assert_invalid
+  (module (global (shared i31ref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null i31))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared i31))))
+  "type mismatch")
+
+;; `nofunc` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_nullfuncref") (shared (shared nullfuncref)))
+  (global (import "spectest" "global_mut_nullfuncref") (shared mut (shared nullfuncref)))
+  (global (import "spectest" "global_ref_null_nofunc") (shared (ref null (shared nofunc))))
+  (global (import "spectest" "global_mut_ref_null_nofunc") (shared mut (ref null (shared nofunc))))
+  (global (import "spectest" "global_ref_nofunc") (shared (ref (shared nofunc))))
+  (global (import "spectest" "global_mut_ref_nofunc") (shared mut (ref (shared nofunc))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared nullfuncref)) (ref.null (shared nofunc)))
+  (global (shared (ref null (shared nofunc))) (ref.null (shared nofunc)))
+)
+
+(assert_invalid
+  (module (global (shared nullfuncref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null nofunc))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared nofunc))))
+  "type mismatch")
+
+;; `noextern` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_nullexternref") (shared (shared nullexternref)))
+  (global (import "spectest" "global_mut_nullexternref") (shared mut (shared nullexternref)))
+  (global (import "spectest" "global_ref_null_noextern") (shared (ref null (shared noextern))))
+  (global (import "spectest" "global_mut_ref_null_noextern") (shared mut (ref null (shared noextern))))
+  (global (import "spectest" "global_ref_noextern") (shared (ref (shared noextern))))
+  (global (import "spectest" "global_mut_ref_noextern") (shared mut (ref (shared noextern))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared nullexternref)) (ref.null (shared noextern)))
+  (global (shared (ref null (shared noextern))) (ref.null (shared noextern)))
+)
+
+(assert_invalid
+  (module (global (shared nullexternref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null noextern))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared noextern))))
+  "type mismatch")
+
+;; `noexn` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_nullexnref") (shared (shared nullexnref)))
+  (global (import "spectest" "global_mut_nullexnref") (shared mut (shared nullexnref)))
+  (global (import "spectest" "global_ref_null_noexn") (shared (ref null (shared noexn))))
+  (global (import "spectest" "global_mut_ref_null_noexn") (shared mut (ref null (shared noexn))))
+  (global (import "spectest" "global_ref_noexn") (shared (ref (shared noexn))))
+  (global (import "spectest" "global_mut_ref_noexn") (shared mut (ref (shared noexn))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared nullexnref)) (ref.null (shared noexn)))
+  (global (shared (ref null (shared noexn))) (ref.null (shared noexn)))
+)
+
+(assert_invalid
+  (module (global (shared nullexnref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null noexn))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared noexn))))
+  "type mismatch")
+
+;; `none` references.
+(module
+  ;; Imported (long/short forms, mut, null).
+  (global (import "spectest" "global_nullref") (shared (shared nullref)))
+  (global (import "spectest" "global_mut_nullref") (shared mut (shared nullref)))
+  (global (import "spectest" "global_ref_null_none") (shared (ref null (shared none))))
+  (global (import "spectest" "global_mut_ref_null_none") (shared mut (ref null (shared none))))
+  (global (import "spectest" "global_ref_none") (shared (ref (shared none))))
+  (global (import "spectest" "global_mut_ref_none") (shared mut (ref (shared none))))
+
+  ;; Initialized (long/short form).
+  (global (shared (shared nullref)) (ref.null (shared none)))
+  (global (shared (ref null (shared none))) (ref.null (shared none)))
+)
+
+(assert_invalid
+  (module (global (shared nullref)))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (shared (ref null none))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module (global (ref (shared none))))
+  "type mismatch")
+
+;; Concrete `func` references.
+(module
+  (type $t (shared (func)))
+
+  ;; Imported.
+  (global (import "spectest" "global_t") (shared (ref $t)))
+  (global (import "spectest" "global_mut_t") (shared mut (ref $t)))
+  (global (import "spectest" "global_null_t") (shared (ref null $t)))
+  (global (import "spectest" "global_mut_null_t") (shared mut (ref null $t)))
+
+  ;; Initialized.
+  (global (shared (ref null $t)) (ref.null $t))
+  (global (shared mut (ref null $t)) (ref.null $t))
+)
+
+(assert_invalid
+  (module
+    (type $t (func))
+    (global (shared (ref $t))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module
+    (type $t (shared (func)))
+    (global (ref $t)))
+  "type mismatch")
+(assert_invalid
+  (module (type $t (shared (func (param funcref)))))
+  "shared composite type must contain shared types")
+
+;; Concrete `array` references.
+(module
+  (type $t (shared (array i32)))
+
+  ;; Imported.
+  (global (import "spectest" "global_t") (shared (ref $t)))
+  (global (import "spectest" "global_mut_t") (shared mut (ref $t)))
+  (global (import "spectest" "global_null_t") (shared (ref null $t)))
+  (global (import "spectest" "global_mut_null_t") (shared mut (ref null $t)))
+
+  ;; Initialized.
+  (global (shared (ref null $t)) (ref.null $t))
+  (global (shared mut (ref null $t)) (ref.null $t))
+)
+
+(assert_invalid
+  (module
+    (type $t (array i32))
+    (global (shared (ref $t))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module
+    (type $t (shared (array i32)))
+    (global (ref $t)))
+  "type mismatch")
+(assert_invalid
+  (module (type $t (shared (array funcref))))
+  "shared composite type must contain shared types")
+
+;; Concrete `struct` references.
+(module
+  (type $t (shared (struct (field i32))))
+
+  ;; Imported.
+  (global (import "spectest" "global_t") (shared (ref $t)))
+  (global (import "spectest" "global_mut_t") (shared mut (ref $t)))
+  (global (import "spectest" "global_null_t") (shared (ref null $t)))
+  (global (import "spectest" "global_mut_null_t") (shared mut (ref null $t)))
+
+  ;; Initialized.
+  (global (shared (ref null $t)) (ref.null $t))
+  (global (shared mut (ref null $t)) (ref.null $t))
+)
+
+(assert_invalid
+  (module
+    (type $t (struct (field i32)))
+    (global (shared (ref $t))))
+  "shared globals must have a shared value type")
+(assert_invalid
+  (module
+    (type $t (shared (struct (field i32))))
+    (global (ref $t)))
+  "type mismatch")
+(assert_invalid
+  (module (type $t (shared (struct (field funcref)))))
+  "shared composite type must contain shared types")


### PR DESCRIPTION
This change starts this proposal's test suite by adding encoding, decoding, and validation tests for the new instructions. This is a wholesale copy of the current state of the `wasm-tools` [tests]. Some things to note:
- some of the tests were generated mechanically to attempt to "cover all possibilities;" not all proposals do this, though, so it's unclear whether we want to here (it's verbose, but hopefully more complete)
- these tests include the component model built-ins, which are not executable in many engines; it's unclear whether to keep that file (the proposal speaks of this) or not
- these tests are a start, not the end state: we're missing anything to do with "thread locals," `pause`, and possibly some other bits.

[tests]: https://github.com/bytecodealliance/wasm-tools/tree/5a83828/tests/local/shared-everything-threads