### PR TITLE
Change from type variables to bot-share for polymorphism

### DIFF
--- a/proposals/shared-everything-threads/Overview.md
+++ b/proposals/shared-everything-threads/Overview.md
@@ -766,16 +766,22 @@ sharecomptype ::= 0x65 ct:comptype => (shared ct) | ct:comptype => (unshared ct)
 
 Several existing instructions need to be updated to accept references to shared heap types in
 addition to the references to unshared heap types they already accept. To allow this flexibility,
-our principal type rule is amended to allow unconstrained sharedness metavariables, just like it
-allows unconstrained nullability metavariables. In general, all instructions that operate on
-references to unshared heap types are allowed to operate on references to shared heap types as well.
+while still allowing instructions to have principal (i.e. unique most specific) types, we introduce
+a bottom shareability, `bot-share`, that is only used for validation purposes. This is analogous the
+use bottom heap type that is already used only for validation purposes.
 
-This is the full list of instructions that need to be updated to accept references to shared heap
-types by way of an unconstrained sharedness metavariable:
+`bot-share` is a subtype of both `shared` and `unshared`, so for example `(ref null (bot-share
+any))` is a subtype of both `anyref` and `(ref null (shared any))`. An instruction whose principle
+type receives `(ref null (bot-share any))` as input can operate on both shared any unshared
+references.
+
+This is the full list of instructions that need to be updated to accept references to `bot-share`
+heap types to allow them to be polymorphic over shared and unshared references.
 
  - `any.convert_extern`
  - `extern.convert_any`
- - `ref.eq` (the sharedness of both operands must match)
+ - `ref.eq` (Mixed-sharedness comparisons are allowed because each operand is independently a
+   subtype of `(ref null (bot-share eq))`, but they are trivially false)
  - `i31.get_s`
  - `i31.get_u`
  - `array.len`


### PR DESCRIPTION
Using type variables to allow instructions to be polymorphic over the
sharedness of their inputs allows for principle typing (up to type
variables), but it does not allow for forward principle typing, since
there is no most-precise instantiation of the type variable to choose
when the available input is a bottom stack. For example, this code
sequence could produce either a `(ref any)` or a `(ref (shared any))`:

```
(unreachable) (any.convert_extern)
```

To fix this, instead introduce a bottom shareability, `bot-share`, that
is analogous to the bottom heap type and used only for validation.

~Besides fixing the forward principle typing property and validation in
unreachable code, this also causes mixed-shareability `ref.eq` to be
allowed again since there is no longer a mechanism for constraining both
of its operands to have the same shareability.~

Fixes #80.
