### PR TITLE
Add validation error for non-atomic instructions with acqrel bit set

### DIFF
--- a/proposals/shared-everything-threads/Overview.md
+++ b/proposals/shared-everything-threads/Overview.md
@@ -722,6 +722,9 @@ future.
 > Note: We may also want to give cmpxchg a third ordering, since some compilation schemes are able
 > to give its read different orderings depending on whether it succeeds or fails.
 
+It is a validation error if any non-atomic instruction that uses a `memarg` (such as standard loads
+and stores) has the `acqrel` bit (bit 5) set.
+
 The new instructions below do not have memarg immediates because they do not operate on memories, so
 they unconditionally take `u8` ordering immediates. `atomic.fence` already has a reserved zero byte
 immediate, which we now interpret as a `u8` ordering immediate, allowing us to express fences with

--- a/proposals/shared-everything-threads/Overview.md
+++ b/proposals/shared-everything-threads/Overview.md
@@ -698,7 +698,8 @@ Just as the multi-memory proposal uses bit 6 of the `memarg` on memory access in
 signify that a memory index follows, we reserve bit 5 to signify that an ordering immediate follows.
 For backward compatibility, if bit 5 is not set, the instruction uses `seqcst` ordering for all
 loads and stores it executes. If a memory index immediate is also present, the ordering immediate
-follows it.
+follows it. It is a validation error if there is an ordering immediate present for any non-atomic
+instruction that uses a `memarg` (such as standard loads and stores).
 
 Ordering immediates are encoded as `u8`s. Read-modify-write operations require two orderings: one
 for the read and one for the write. For RMWs, the low four bits of the `u8` encode the read ordering
@@ -721,9 +722,6 @@ future.
 
 > Note: We may also want to give cmpxchg a third ordering, since some compilation schemes are able
 > to give its read different orderings depending on whether it succeeds or fails.
-
-It is a validation error if any non-atomic instruction that uses a `memarg` (such as standard loads
-and stores) has the `acqrel` bit (bit 5) set.
 
 The new instructions below do not have memarg immediates because they do not operate on memories, so
 they unconditionally take `u8` ordering immediates. `atomic.fence` already has a reserved zero byte


### PR DESCRIPTION
This PR adds the missed note about handling non-atomic instructions when the `acqrel` bit (bit 5) set.