### PR TITLE
Shared string builtins

### DIFF
--- a/proposals/shared-everything-threads/Overview.md
+++ b/proposals/shared-everything-threads/Overview.md
@@ -572,6 +572,11 @@ is shared, and 2) uses `(shared extern)` in place of `extern` (and also shared v
 heap types, e.g. the array parameter in `fromCharCodeArray`). Mixing shared and unshared heap types
 in the same signature is not allowed.
 
+Similarly, imported string constants can also be shared. They are imported from the same configured
+`importedStringModule` as non-shared string constants, but are imported as globals with type
+`(ref (shared extern))` or `(ref null (shared extern))`. Notably, no spec changes are required for
+this to work once strings are allowed to enter Wasm as shared extern references.
+
 [string-builtins]: https://webassembly.github.io/spec/js-api/#builtins-js-string
 
 #### Shared Annotations

--- a/proposals/shared-everything-threads/Overview.md
+++ b/proposals/shared-everything-threads/Overview.md
@@ -565,7 +565,7 @@ Waitqueue references are converted to `WebAssembly.WaitQueue` objects, described
 #### Shared String Builtins
 
 As mentioned above, JS strings will be able to be converted to `(ref extern)` or
-`(ref (shared extern)` when entering WebAssembly. To facilitate working with shared strings,
+`(ref (shared extern))` when entering WebAssembly. To facilitate working with shared strings,
 the [string builtins][string-builtins] will each be updated to be importable with two function types:
 the current function type using `extern` and a new function type that is equivalent except that 1) it
 is shared, and 2) uses `(shared extern)` in place of `extern` (and also shared versions of any other

--- a/proposals/shared-everything-threads/Overview.md
+++ b/proposals/shared-everything-threads/Overview.md
@@ -562,6 +562,18 @@ Waitqueue references are converted to `WebAssembly.WaitQueue` objects, described
 
 [proposal-structs]: https://github.com/tc39/proposal-structs
 
+#### Shared String Builtins
+
+As mentioned above, JS strings will be able to be converted to `(ref extern)` or
+`(ref (shared extern)` when entering WebAssembly. To facilitate working with shared strings,
+the [string builtins][string-builtins] will each be updated to be importable with two function types:
+the current function type using `extern` and a new function type that is equivalent except that 1) it
+is shared, and 2) uses `(shared extern)` in place of `extern` (and also shared versions of any other
+heap types, e.g. the array parameter in `fromCharCodeArray`). Mixing shared and unshared heap types
+in the same signature is not allowed.
+
+[string-builtins]: https://webassembly.github.io/spec/js-api/#builtins-js-string
+
 #### Shared Annotations
 
 Just like the original threads proposal exposed shared memories in the JS API, this proposal exposes


### PR DESCRIPTION
Describe overloading the existing string builtins to be importable with shared versions of the existing signatures.